### PR TITLE
Add image fallback directive and UiSharedModule; apply to product images

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -48,6 +48,7 @@ import { OverviewComponent } from './features/cart-view/overview/overview.compon
 import { PaymentComponent } from './features/cart-view/payment/payment.component';
 import { CartItemComponent } from './features/cart-view/cart-item/cart-item.component';
 import { SlideMenuModule } from 'primeng/slidemenu';
+import { UiSharedModule } from './shared/ui-shared.module';
 
 @NgModule({
   declarations: [
@@ -88,7 +89,8 @@ import { SlideMenuModule } from 'primeng/slidemenu';
     SlideMenuModule,
     CardModule,
     RadioButtonModule,
-    ReactiveFormsModule
+    ReactiveFormsModule,
+    UiSharedModule
   ],
   exports: [],
   providers: [

--- a/src/app/features/cart-view/cart-item/cart-item.component.html
+++ b/src/app/features/cart-view/cart-item/cart-item.component.html
@@ -3,7 +3,7 @@
   <p-button class="remove-btn" icon="pi pi-times" (click)="removeItem(product)"
             styleClass="p-button-rounded p-button-danger p-button-text"></p-button>
   <div class="flex align-items-center">
-    <img class="cursor-pointer" (click)="openDetails(product.id)" [src]="product.images[0]" height="120px"
+    <img appFallbackImage class="cursor-pointer" (click)="openDetails(product.id)" [src]="product.images[0]" height="120px"
          width="120px" [alt]="product.name">
     <div class="flex flex-column">
       <h2 class="p-0 m-0 max-w-18rem">{{ product.name }}</h2>

--- a/src/app/features/cart-view/cart-view.component.html
+++ b/src/app/features/cart-view/cart-view.component.html
@@ -26,7 +26,7 @@
         <p-button class="remove-btn" icon="pi pi-times" (click)="removeFromCart(product)"
           styleClass="p-button-rounded p-button-danger p-button-text"></p-button>
         <div class="flex align-items-center">
-          <img class="cursor-pointer" (click)="openProductDetails(product.id)" [src]="product.images[0]" height="100px"
+          <img appFallbackImage class="cursor-pointer" (click)="openProductDetails(product.id)" [src]="product.images[0]" height="100px"
             width="100px" [alt]="product.name" class="mr-3">
           <div class="flex flex-column">
             <h2 class="p-0 m-0 max-w-18rem">{{ product.name }}</h2>

--- a/src/app/features/home/home.component.html
+++ b/src/app/features/home/home.component.html
@@ -4,7 +4,7 @@
   <div
     class="flex flex-column md:flex-row align-items-center justify-content-center cursor-pointer border-round-2xl border-1 surface-border w-full transition-duration-300 hover:shadow-2 hover:border-primary mb-3 md:mb-0 shadow-2"
     (click)="redirect(macbookId)" style="min-height: 420px">
-    <img alt="macbook image" [src]="macbookImg" class="w-full md:w-6 h-auto object-cover"
+    <img appFallbackImage alt="macbook image" [src]="macbookImg" class="w-full md:w-6 h-auto object-cover"
       style="max-width: 250px; max-height: 250px;" />
     <div class="flex flex-column p-3">
       <h2 class="p-0 m-0 mb-2">Macbook Air M1</h2>
@@ -24,7 +24,7 @@
     <div
       class="flex flex-column md:flex-row cursor-pointer align-items-center justify-content-start border-1 surface-border w-full border-round-2xl transition-duration-300 hover:shadow-2 hover:border-primary mb-3 shadow-2"
       (click)="redirect(ipadId)">
-      <img class="border-round-2xl w-full md:w-4 h-auto object-cover" alt="ipad image" [src]="ipadImg"
+      <img appFallbackImage class="border-round-2xl w-full md:w-4 h-auto object-cover" alt="ipad image" [src]="ipadImg"
         style="max-width: 250px; max-height: 250px;" />
       <div class="flex flex-column p-3">
         <h2 class="p-0 m-0 mb-2">iPad Pro M2</h2>
@@ -40,7 +40,7 @@
     <div
       class="flex flex-column md:flex-row cursor-pointer align-items-center justify-content-start border-1 surface-border w-full border-round-2xl transition-duration-300 hover:shadow-2 hover:border-primary shadow-2"
       (click)="redirect(iphoneId)">
-      <img class="border-round-2xl w-full md:w-4 h-auto object-cover" alt="iphone image" [src]="iphoneImg"
+      <img appFallbackImage class="border-round-2xl w-full md:w-4 h-auto object-cover" alt="iphone image" [src]="iphoneImg"
         style="max-width: 250px; max-height: 250px;" />
       <div class="flex flex-column p-3">
         <h2 class="p-0 m-0 mb-2">iPhone 14 Pro Max</h2>

--- a/src/app/features/home/suggested-product/suggested-product.component.html
+++ b/src/app/features/home/suggested-product/suggested-product.component.html
@@ -5,7 +5,7 @@
     <span class="text-white font-light">New</span>
   </div>
 
-  <img [src]="image" class="w-full h-auto md:w-12rem md:h-12rem object-contain" alt="name">
+  <img appFallbackImage [src]="image" class="w-full h-auto md:w-12rem md:h-12rem object-contain" alt="name">
 
   <span class="product-name font-bold text-center mt-2">
     {{name}}

--- a/src/app/features/products/product/product-details/product-details.component.html
+++ b/src/app/features/products/product/product-details/product-details.component.html
@@ -20,7 +20,7 @@
                                          class="thumbnail-item"
                                          [ngClass]="{'active': activeIndex === index}"
                                          (click)="imageClick(index)">
-                                        <img [src]="image"
+                                        <img appFallbackImage [src]="image"
                                              class="w-full h-auto border-round"
                                              [alt]="image">
                                     </div>

--- a/src/app/features/products/product/product.component.html
+++ b/src/app/features/products/product/product.component.html
@@ -4,7 +4,7 @@
     <div class="relative flex flex-column align-items-center" style="height: 100%;">
         <div class="image-container flex justify-center items-center"
              style="height: 200px; width: 200px; max-width: 100%; margin-bottom: 10px;">
-            <img (click)="openProductDetails(id)" [src]="images[0]" [alt]="name"
+            <img appFallbackImage (click)="openProductDetails(id)" [src]="images[0]" [alt]="name"
                  class="max-h-full max-w-full object-contain cursor-pointer" style="align-self: center; margin: auto;">
         </div>
         <i (click)="addRemoveItemWishlist(product)" class="favorite absolute top-2 right-2 z-10 text-xl cursor-pointer"
@@ -42,7 +42,7 @@
            [class]="inWishlist ? 'pi pi-heart-fill wishlist' : 'pi pi-heart'"></i>
         <!-- Left side -->
         <div class="flex flex-column items-center md:items-start md:flex-row">
-            <img (click)="openProductDetails(id)" [src]="images[0]" [alt]="name"
+            <img appFallbackImage (click)="openProductDetails(id)" [src]="images[0]" [alt]="name"
                  class="w-48 h-48 object-contain cursor-pointer md:mb-0 md:mr-5 align-self-center md:align-self-auto"
                  style="max-width: 200px; max-height: 200px;">
             <div style="max-width: 600px;"

--- a/src/app/features/products/products.module.ts
+++ b/src/app/features/products/products.module.ts
@@ -31,6 +31,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { AppRoutingModule } from 'src/app/app-routing.module';
 import { InputTextareaModule } from 'primeng/inputtextarea';
+import { UiSharedModule } from 'src/app/shared/ui-shared.module';
 
 @NgModule({
   declarations: [
@@ -66,7 +67,8 @@ import { InputTextareaModule } from 'primeng/inputtextarea';
     InputNumberModule,
     SkeletonModule,
     StepsModule,
-    ToastModule
+    ToastModule,
+    UiSharedModule
   ],
   exports: [
     ProductsViewComponent,

--- a/src/app/shared/fallback-image.directive.ts
+++ b/src/app/shared/fallback-image.directive.ts
@@ -1,0 +1,47 @@
+import { AfterViewInit, Directive, ElementRef, HostListener, Input, OnChanges, SimpleChanges } from '@angular/core';
+
+@Directive({
+  selector: 'img[appFallbackImage]'
+})
+export class FallbackImageDirective implements AfterViewInit, OnChanges {
+  @Input() appFallbackImage = 'assets/placeholder-image.svg';
+  @Input() src: string | null = null;
+
+  constructor(private readonly elementRef: ElementRef<HTMLImageElement>) {}
+
+  ngAfterViewInit(): void {
+    this.syncImageSource();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['src'] || changes['appFallbackImage']) {
+      this.syncImageSource();
+    }
+  }
+
+  @HostListener('error')
+  onError(): void {
+    this.setPlaceholder();
+  }
+
+  private syncImageSource(): void {
+    const normalizedSource = (this.src ?? '').trim();
+
+    if (!normalizedSource) {
+      this.setPlaceholder();
+      return;
+    }
+
+    this.elementRef.nativeElement.src = normalizedSource;
+  }
+
+  private setPlaceholder(): void {
+    const imageElement = this.elementRef.nativeElement;
+
+    if (imageElement.src.includes(this.appFallbackImage)) {
+      return;
+    }
+
+    imageElement.src = this.appFallbackImage;
+  }
+}

--- a/src/app/shared/ui-shared.module.ts
+++ b/src/app/shared/ui-shared.module.ts
@@ -1,0 +1,8 @@
+import { NgModule } from '@angular/core';
+import { FallbackImageDirective } from './fallback-image.directive';
+
+@NgModule({
+  declarations: [FallbackImageDirective],
+  exports: [FallbackImageDirective]
+})
+export class UiSharedModule {}

--- a/src/assets/placeholder-image.svg
+++ b/src/assets/placeholder-image.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300" role="img" aria-labelledby="title desc">
+  <title id="title">Image unavailable</title>
+  <desc id="desc">Placeholder shown when product image cannot be loaded.</desc>
+  <rect width="400" height="300" fill="#e8e8e8"/>
+  <g fill="none" stroke="#c8c8c8" stroke-width="10" stroke-linejoin="round">
+    <rect x="120" y="70" width="120" height="90"/>
+    <rect x="160" y="105" width="140" height="100"/>
+  </g>
+  <g fill="#d3d3d3">
+    <circle cx="195" cy="135" r="11"/>
+    <path d="M175 185l30-28 20 20 30-36 25 44z"/>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation

- Provide a consistent placeholder image when product images fail to load by centralizing fallback behavior in a directive.
- Reduce duplication and keep template markup simple by exposing the directive from a shared UI module.
- Ensure multiple product-related components use the same fallback behavior for a better UX when remote images are unavailable.

### Description

- Added a new `FallbackImageDirective` in `src/app/shared/fallback-image.directive.ts` that listens for image load errors and substitutes a default placeholder, and it accepts an optional `appFallbackImage` input for custom placeholders.
- Introduced `UiSharedModule` in `src/app/shared/ui-shared.module.ts` which declares and exports the `FallbackImageDirective` for reuse across feature modules.
- Added a placeholder asset `src/assets/placeholder-image.svg` used by the directive as the default fallback image.
- Updated various templates to apply the directive (`appFallbackImage`) to product and hero images and registered `UiSharedModule` in both `AppModule` and `ProductsModule` imports so the directive is available application-wide.

### Testing

- No automated tests were added for this change.
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a005c87a24832ab509f95af06e4bd9)