### PR TITLE
Improve product UX responsiveness and image fallback reliability

### DIFF
--- a/src/app/features/home/home.component.ts
+++ b/src/app/features/home/home.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { Subscription } from "rxjs";
 import { ProductsService } from '../products/products.service';
+import { ProductImageService } from 'src/app/shared/product-image.service';
 
 @Component({
   selector: 'app-home',
@@ -43,12 +44,16 @@ export class HomeComponent implements OnInit {
 
   constructor(
     private router: Router,
-    private _productService: ProductsService
+    private _productService: ProductsService,
+    private _productImageService: ProductImageService
   ) { }
 
   ngOnInit() {
     this.suggestedProductsSubscription = this._productService.getSuggestedProducts().subscribe((products: any) => {
-      this.suggestedProducts = products.data.product;
+      this.suggestedProducts = products.data.product.map((product: any) => ({
+        ...product,
+        images: this._productImageService.normalizeImages(product.images, product.name)
+      }));
     })
   }
 

--- a/src/app/features/products/product/product-details/product-details.component.html
+++ b/src/app/features/products/product/product-details/product-details.component.html
@@ -106,7 +106,7 @@
         <h2 class="text-center">Suggested products from category {{ product.category?.name }}</h2>
     </ng-template>
     <ng-template let-product pTemplate="item">
-        <div class="flex align-items-center justify-content-center">
+        <div class="flex align-items-center justify-content-center w-full p-2">
             <app-product class="mt-2 mb-2 w-full sm:w-auto"
                          (addedToCart)="addToCart($event)"
                          (replaceCurrentProduct)="replaceProduct($event)"
@@ -114,7 +114,7 @@
                          (removedFromWishList)="removedFromWishList($event)"
                          (addedToWishList)="addToWishList($event)"
                          [name]="product.name"
-                         [subcategory]="product.subcategory.name"
+                         [subcategory]="product.subcategory"
                          [id]="product.id"
                          [images]="product.images"
                          [inStock]="product.inStock"

--- a/src/app/features/products/product/product-details/product-details.component.scss
+++ b/src/app/features/products/product/product-details/product-details.component.scss
@@ -1,11 +1,8 @@
 $sm: 576px;
 $md: 768px;
-$lg: 992px;
-$xl: 1200px;
 
 :host ::ng-deep {
   .custom-galleria {
-
     .product-gallery-container {
       display: flex;
       flex-direction: column;
@@ -14,84 +11,62 @@ $xl: 1200px;
 
       @media screen and (min-width: $md) {
         flex-direction: row;
-        gap: 2rem;
+        gap: 1.5rem;
+      }
+    }
+
+    .thumbnails-wrapper {
+      @media screen and (min-width: $md) {
+        order: -1;
+        width: 88px;
+      }
+    }
+
+    .thumbnails-container {
+      display: flex;
+      gap: .5rem;
+      overflow-x: auto;
+
+      @media screen and (min-width: $md) {
+        flex-direction: column;
+        gap: .75rem;
+      }
+    }
+
+    .thumbnail-item {
+      flex: 0 0 auto;
+      width: 70px;
+      height: 70px;
+      padding: .3rem;
+      border: 1px solid var(--surface-200);
+      border-radius: var(--border-radius);
+      cursor: pointer;
+      transition: all .2s;
+      background: var(--surface-ground);
+
+      &:hover,
+      &.active {
+        border-color: var(--primary-color);
+        transform: scale(1.03);
       }
 
-      .thumbnails-wrapper {
-        @media screen and (min-width: $md) {
-          order: -1;
-          width: 100px;
-        }
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
       }
 
-      .thumbnails-container {
-        display: flex;
-        gap: 0.5rem;
-
-        @media screen and (max-width: $md - 1px) {
-          overflow-x: auto;
-          padding-bottom: 0.5rem;
-          flex-direction: row;
-        }
-
-        @media screen and (min-width: $md) {
-          flex-direction: column;
-          gap: 1rem;
-        }
+      @media screen and (max-width: $sm) {
+        width: 56px;
+        height: 56px;
       }
+    }
 
-      .thumbnail-item {
-        flex: 0 0 auto;
-        width: 80px;
-        height: 80px;
-        padding: 0.5rem;
-        border: 1px solid var(--surface-200);
-        border-radius: var(--border-radius);
-        cursor: pointer;
-        transition: all 0.2s;
-        background: var(--surface-ground);
-
-        &:hover, &.active {
-          border-color: var(--primary-color);
-          transform: scale(1.05);
-        }
-
-        img {
-          width: 100%;
-          height: 100%;
-          object-fit: cover;
-        }
-
-        @media screen and (max-width: $sm) {
-          width: 60px;
-          height: 60px;
-          padding: 0.25rem;
-        }
-      }
-
-      .main-image-wrapper {
-        flex: 1;
-
-        ::ng-deep img {
-          max-width: 100%;
-          height: auto;
-          object-fit: contain;
-        }
-      }
-
-      // Responsive image preview
-      .p-image {
-        .p-image-preview-container {
-          max-width: 100vw;
-          max-height: 90vh;
-
-          img {
-            max-width: 800px;
-            max-height: 600px;
-            object-fit: contain;
-          }
-        }
-      }
+    .main-image-wrapper ::ng-deep img {
+      max-width: 100%;
+      height: auto;
+      object-fit: contain;
+      max-height: 450px;
     }
 
     .p-galleria-indicators,
@@ -101,44 +76,26 @@ $xl: 1200px;
   }
 }
 
-.product-item {
-  .product-item-content {
-    border: 1px solid var(--surface-d);
-    border-radius: 3px;
-    margin: 0.3rem;
-    text-align: center;
-    padding: 2rem 0;
-    min-height: 452px;
-  }
-
-  .product-image {
-    width: 50%;
-    max-width: 250px;
-    max-height: 250px;
-    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
-  }
-}
-
 .product-price {
   font-size: 1.5rem;
   font-weight: 600;
-  align-self: flex-start;
+}
+
+.tag,
+.favorite {
+  position: absolute;
+  top: 0;
 }
 
 .tag {
-  position: absolute;
   left: 0;
-  top: 0;
 }
 
 .favorite {
-  font-size: 1.5rem;
-  position: absolute;
-  top: 0;
   right: 0;
   padding: 10px;
+  font-size: 1.5rem;
   cursor: pointer;
-  filter: drop-shadow(0 0.2rem 0.25rem rgba(0, 0, 0, 0.1));
 }
 
 .wishlist {

--- a/src/app/features/products/product/product-details/product-details.component.ts
+++ b/src/app/features/products/product/product-details/product-details.component.ts
@@ -92,7 +92,12 @@ export class ProductDetailsComponent implements OnInit {
       const productCategory = state?.product.category?.name;
       this._productService.getProductsByCategory(productCategory).subscribe((suggestedProducts: any) => {
         // TODO: filter out the currently selected item and remove it from suggestions list
-        this.suggestedProducts = suggestedProducts.data.product;
+        this.suggestedProducts = suggestedProducts.data.product
+          .filter((suggestedProduct: Product) => suggestedProduct.id !== this.id)
+          .map((suggestedProduct: Product) => ({
+            ...suggestedProduct,
+            images: this._productImageService.normalizeImages(suggestedProduct.images, suggestedProduct.name)
+          }));
         // Undefined when user reload the page or goes directly to this route
       })
     }
@@ -113,7 +118,12 @@ export class ProductDetailsComponent implements OnInit {
         // Suggested products
         const productCategory = product.data.product[0].category?.name;
         this._productService.getProductsByCategory(productCategory).subscribe((suggestedProducts: any) => {
-          this.suggestedProducts = suggestedProducts.data.product;
+          this.suggestedProducts = suggestedProducts.data.product
+          .filter((suggestedProduct: Product) => suggestedProduct.id !== this.id)
+          .map((suggestedProduct: Product) => ({
+            ...suggestedProduct,
+            images: this._productImageService.normalizeImages(suggestedProduct.images, suggestedProduct.name)
+          }));
         })
       })
       this.inWishlist = this.checkInWishlist(this.id);
@@ -216,13 +226,18 @@ export class ProductDetailsComponent implements OnInit {
   }
 
   replaceProduct(id: number) {
-    const newProduct = this.suggestedProducts.find((p) => p.id == id)
+    const newProduct = this.suggestedProducts.find((p) => p.id === id);
+    if (!newProduct) {
+      return;
+    }
+
     this.id = newProduct.id;
-    this.inWishlist = this.checkIfInWishlist(newProduct.id);
+    this.inWishlist = this.checkIfInWishlist(newProduct);
     this.product = newProduct;
     this.images = this._productImageService.normalizeImages(newProduct.images, newProduct.name);
     this.product.images = this.images;
-    this.router.navigate(['/product', newProduct.id])
+    this.setBreadcrumbItems();
+    this.router.navigate(['/product', newProduct.id]);
   }
 
   buyProduct(product: Product) {

--- a/src/app/features/products/product/product.component.scss
+++ b/src/app/features/products/product/product.component.scss
@@ -4,35 +4,18 @@
 
 .product-card {
   width: 100%;
-  height: auto;
+  min-height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
   flex-direction: column;
   border-radius: 15px;
   border: 1px solid rgba(243, 243, 243, 0.8);
-  backdrop-filter: blur(3px);
   background-color: #ffffff;
   position: relative;
   margin: 0;
   filter: drop-shadow(0 0.2rem 0.25rem rgba(0, 0, 0, 0.1));
-  transition: 0.5s ease-out;
-
-  @media (min-width: 640px) {
-    width: 50%;
-  }
-
-  @media (min-width: 768px) {
-    width: 33.33%;
-  }
-
-  @media (min-width: 1024px) {
-    width: 25%;
-  }
-
-  @media (min-width: 1280px) {
-    width: 20%;
-  }
+  transition: 0.3s ease-out;
 
   &:hover {
     filter: drop-shadow(0 0.2rem 0.25rem rgba(0, 0, 0, 0.3));
@@ -45,51 +28,6 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.title-section {
-  display: flex;
-  flex-direction: column;
-  max-width: 90%;
-  flex-grow: 2;
-}
-
-.bottom-left {
-  display: flex;
-  justify-content: center;
-  align-items: space-between;
-  flex-direction: column;
-  padding: 20px 0px 10px 20px;
-  width: 100%;
-}
-
-.bottom-right {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  width: 100%;
-  padding: 10px 10px 0 10px;
-}
-
-.item-bottom {
-  display: flex;
-  width: 100%;
-  align-items: center;
-  justify-content: space-around;
-  flex-grow: 1;
-  padding: 10px;
-}
-
-.image {
-  width: 100%;
-  max-width: 250px;
-  max-height: 250px;
-  height: 250px;
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: center;
-  cursor: pointer;
-  margin: 0 auto;
 }
 
 .favorite {
@@ -105,24 +43,13 @@
   color: red;
 }
 
-.cart {
-  border: 1px solid #e9e9e9;
-  padding: 10px;
-  border-radius: 50%;
-
-  &:hover {
-    background-color: rgba(198, 198, 198, 0.25);
-    cursor: pointer;
-  }
-}
-
 .product-list-container {
   background-color: #f3f3f3;
   filter: drop-shadow(0 0.2rem 0.25rem rgba(0, 0, 0, 0.2));
-  transition: 0.5s ease-out;
+  transition: 0.3s ease-out;
 
   &:hover {
-    filter: drop-shadow(0 0.2rem 0.25rem rgba(0, 0, 0, 0.5));
+    filter: drop-shadow(0 0.2rem 0.25rem rgba(0, 0, 0, 0.45));
     background-color: #f8f8f8;
   }
 }

--- a/src/app/features/products/products-view.component.scss
+++ b/src/app/features/products/products-view.component.scss
@@ -7,52 +7,8 @@
   margin-bottom: 10px;
 }
 
-.flex {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
 ::ng-deep .p-dataview .p-dataview-header {
   border-radius: 15px !important;
-}
-
-.product-list-item {
-  display: flex;
-  align-items: center;
-  padding: 1rem;
-  width: 100%;
-
-  img {
-    width: 150px;
-    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
-    margin-right: 2rem;
-  }
-
-  .product-list-detail {
-    flex: 1 1 0;
-  }
-
-  .favorite {
-    font-size: 1.5rem;
-    position: absolute;
-    top: 0;
-    right: 0;
-    padding: 10px;
-    cursor: pointer;
-    filter: drop-shadow(0 0.2rem 0.25rem rgba(0, 0, 0, 0.1));
-  }
-
-  .product-price {
-    font-size: 1.5rem;
-    font-weight: 600;
-    margin-bottom: 0.5rem;
-    align-self: flex-end;
-  }
-
-  .p-button {
-    margin-bottom: 0.5rem;
-  }
 }
 
 .p-dropdown {
@@ -60,38 +16,8 @@
   font-weight: normal;
 }
 
-.product-name {
-  font-size: 1.5rem;
-  font-weight: 700;
-}
-
-.product-description {
-  margin: 0 0 1rem 0;
-}
-
-.product-category-icon {
-  vertical-align: middle;
-  margin-right: 0.5rem;
-}
-
-.product-category {
-  font-weight: 600;
-  vertical-align: middle;
-}
-
-.class {
-  max-width: 100px;
-}
-
-::ng-deep
-  body
-  > app-root
-  > div
-  > app-products-view
-  > div
-  > div.surface-overlay.px-2.py-3
-  > p-slider
-  > div
-  > span.p-slider-range.ng-star-inserted {
-  width: 250px;
+@media (max-width: 768px) {
+  .p-dropdown {
+    width: 100%;
+  }
 }

--- a/src/app/features/products/products-view.component.ts
+++ b/src/app/features/products/products-view.component.ts
@@ -31,8 +31,8 @@ export class ProductsViewComponent implements OnInit, OnDestroy {
   priceTo!: number;
   rangeValues: number[] = [];
 
-  highestPrice: number = 0;
-  lowestPrice: number = 0;
+  highestPrice = 0;
+  lowestPrice = 0;
 
   numberOfProducts!: number;
   isLoading = true;
@@ -68,19 +68,9 @@ export class ProductsViewComponent implements OnInit, OnDestroy {
 
       const sortedPrices = [...products.data.product].sort((productA: any, productB: any) => (productA.price - productB.price))
 
-      this.highestPrice = sortedPrices[0].price
-      this.lowestPrice = sortedPrices.at(-1).price;
-      this.rangeValues = [this.highestPrice, this.lowestPrice];
-
-      products.data.product.forEach((product: Product) => {
-        if (product.price > this.highestPrice) {
-          this.highestPrice = product.price;
-        };
-
-        if (product.price < this.lowestPrice) {
-          this.lowestPrice = product.price;
-        };
-      });
+      this.lowestPrice = sortedPrices[0]?.price ?? 0;
+      this.highestPrice = sortedPrices.at(-1)?.price ?? 0;
+      this.rangeValues = [this.lowestPrice, this.highestPrice];
     }));
 
     this.subs.add(this._productService.getProductCategories().subscribe((categories: any) => {
@@ -109,7 +99,7 @@ export class ProductsViewComponent implements OnInit, OnDestroy {
   }
 
   trackByProductId(index: number, product: Product): number {
-    return index;
+    return product.id;
   }
 
   applyFilters(filtersObject: any) {

--- a/src/app/shared/product-image.service.ts
+++ b/src/app/shared/product-image.service.ts
@@ -5,6 +5,7 @@ import { Injectable } from '@angular/core';
 })
 export class ProductImageService {
   private readonly fallbackAssetPath = 'assets/images/product-placeholder.png';
+  private readonly maxProductImages = 2;
 
   getFallbackImageByName(productName?: string | null): string {
     const trimmedName = productName?.trim();
@@ -22,11 +23,18 @@ export class ProductImageService {
       .map((image) => image?.trim())
       .filter((image): image is string => Boolean(image));
 
-    if (validImages.length > 0) {
-      return validImages;
+    const limitedImages = validImages.slice(0, this.maxProductImages);
+
+    if (limitedImages.length >= this.maxProductImages) {
+      return limitedImages;
     }
 
-    return [this.getFallbackImageByName(productName)];
+    if (limitedImages.length === 1) {
+      return [limitedImages[0], this.getFallbackImageByName(productName)];
+    }
+
+    const fallback = this.getFallbackImageByName(productName);
+    return [fallback, this.getFallbackAssetPath()];
   }
 
   resolvePrimaryImage(images: string[] | null | undefined, productName?: string | null): string {


### PR DESCRIPTION
### Motivation

- Ensure product galleries never exceed two images and provide resilient fallbacks when images are missing or invalid.  
- Improve responsive layout and styling to better match installed UI libs (`primeng`, `primeflex`, `tailwind` utilities) and reduce visual breakage across breakpoints.  
- Fix a few runtime UX bugs: suggested-products showing the same product, incorrect `subcategory` binding on suggested cards, and incorrect min/max price initialization in the product list.

### Description

- Updated `ProductImageService` to enforce a `maxProductImages = 2`, return name-based and asset fallbacks, and provide `resolvePrimaryImage`/`normalizeImages` behavior that always returns a 2-slot array when needed (file: `src/app/shared/product-image.service.ts`).  
- Hardened product details logic to exclude the current product from suggestions, normalize suggestion images via `ProductImageService`, guard `replaceProduct` against nulls, update breadcrumbs after replacement, and fix wishlist checks (file: `src/app/features/products/product/product-details/product-details.component.ts`).  
- Fixed a template bug by passing the full `subcategory` object to the suggested product card instead of a string (file: `src/app/features/products/product/product-details/product-details.component.html`).  
- Corrected price-range initialization and `trackBy` behavior in products view so `lowestPrice`/`highestPrice` are set safely and `trackByProductId` returns `product.id` (file: `src/app/features/products/products-view.component.ts`).  
- Normalized suggested products on the home page to use `ProductImageService.normalizeImages` so the UI receives reliable image arrays (file: `src/app/features/home/home.component.ts`).  
- Simplified/resized SCSS used by product cards, product-details gallery and products view to improve responsiveness and avoid conflicting or overly broad rules (files: `src/app/features/products/product/product.component.scss`, `src/app/features/products/product/product-details/product-details.component.scss`, `src/app/features/products/products-view.component.scss`).

### Testing

- Built the application with `npm run build` and the build completed successfully.  
- Started the dev server with `npm start -- --host 0.0.0.0 --port 4200` and executed a headless Playwright script to capture a full-page screenshot as an automated UI smoke check (artifact produced during the run).  
- Both automated checks completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a95fac3d3c832a899f6c1657e8eb9b)