### PR TITLE
security: remove hardcoded Hasura admin secret + remediate audit findings

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security
+
+## Reporting
+
+Please report security issues privately to the repository owner rather than
+opening a public issue.
+
+## Backend configuration required (action needed)
+
+This is a client-only Angular SPA. It talks to a hosted Hasura GraphQL API and
+**must not** carry any database credentials, because all client-side code is
+shipped to the browser and is publicly readable.
+
+### 1. Rotate the leaked Hasura admin secret — URGENT
+
+A Hasura `x-hasura-admin-secret` was previously hardcoded in
+`src/app/app.module.ts`. It was compiled into every production bundle and is
+present in this repository's git history, so it must be treated as fully
+compromised:
+
+- Rotate (regenerate) the admin secret in the Hasura Cloud dashboard now.
+- Keep the new admin secret server-side only (Hasura console / env vars). Never
+  place it in this repository or in any front-end code.
+
+### 2. Expose the catalog through a read-only `anonymous` role
+
+The app only **reads** the public product catalog (there are no mutations). Give
+Hasura's `anonymous` role `select` permission so the storefront works without
+any secret:
+
+- In Hasura → **Settings → Roles/Permissions**, enable the `anonymous` role
+  (set `HASURA_GRAPHQL_UNAUTHORIZED_ROLE=anonymous`).
+- Grant `anonymous` **`select`-only** permission (no insert/update/delete) on the
+  tables the catalog uses: `product`, `category`, `subcategory`.
+- Limit selectable columns to those actually rendered by the UI and, if desired,
+  add row limits/aggregation limits to prevent scraping abuse.
+
+The browser sends **no** auth header (see `app.module.ts`), so until the
+`anonymous` role is configured the deployed app will receive
+"permission denied" for catalog queries. The app still builds and deploys; only
+live data depends on this backend step.
+
+### 3. Lock down the endpoint
+
+- Restrict Hasura **CORS** to your production/staging origins only.
+- Disable schema introspection in production.
+- Consider Hasura's allow-list so only the queries this app uses are accepted.
+
+## Tracked follow-ups
+
+- **Dependency upgrades:** the app is on end-of-life Angular 15 / PrimeNG 15 with
+  known high-severity advisories. A major-version migration is tracked separately.
+- **Authentication / authorization:** there is currently no user auth. If
+  authenticated features (orders, accounts, writes) are added, introduce JWT/session
+  auth with per-role Hasura permissions and Angular route guards. Tracked separately.

--- a/angular.json
+++ b/angular.json
@@ -32,6 +32,7 @@
             ],
             "styles": [
               "src/styles.scss",
+              "node_modules/primeflex/primeflex.css",
               "node_modules/primeicons/primeicons.css",
               "node_modules/primeng/resources/themes/lara-light-blue/theme.css",
               "node_modules/primeng/resources/primeng.min.css"
@@ -98,6 +99,7 @@
             ],
             "styles": [
               "src/styles.scss",
+              "node_modules/primeflex/primeflex.css",
               "node_modules/primeicons/primeicons.css",
               "node_modules/primeng/resources/themes/lara-light-blue/theme.css",
               "node_modules/primeng/resources/primeng.min.css"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,15 @@
+# Netlify build configuration, committed to the repo so every connected site
+# builds this project with identical, correct settings (instead of relying on
+# per-site dashboard configuration).
+#
+# Publish dir matches `outputPath` in angular.json ("dist/project").
+# SPA route fallback continues to be provided by src/_redirects (copied into the
+# publish directory as part of the Angular build assets).
+
+[build]
+  command = "npm run build"
+  publish = "dist/project"
+
+[build.environment]
+  # Angular 15 supports Node 18.x; pin it for reproducible builds.
+  NODE_VERSION = "18"

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,8 +13,9 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 // Apollo
 import { ApolloModule, APOLLO_OPTIONS } from 'apollo-angular'
 import { HttpLink } from 'apollo-angular/http';
-import { HttpClientModule, HttpHeaders } from '@angular/common/http';
+import { HttpClientModule } from '@angular/common/http';
 import { InMemoryCache } from '@apollo/client/core';
+import { environment } from '../environments/environment';
 
 // Feature modules
 import { ProductsModule } from './features/products/products.module';
@@ -99,11 +100,12 @@ import { SlideMenuModule } from 'primeng/slidemenu';
       useFactory(httpLink: HttpLink) {
         return {
           cache: new InMemoryCache(),
+          // No authorization header is sent from the browser. A Hasura admin secret
+          // must NEVER be embedded in client-side code: it ships in the JS bundle and
+          // grants full database access to anyone who reads it. The public catalog is
+          // served by Hasura's read-only "anonymous" role (see SECURITY.md).
           link: httpLink.create({
-            uri: 'https://webshop.hasura.app/v1/graphql',
-            headers: new HttpHeaders({
-              "x-hasura-admin-secret": "6sftAV4UtDQ6V26v1p4U4mDAS8eXiDDnBo62JFsQbdTjksQQjcF54reBmrA2p7Jl"
-            }),
+            uri: environment.graphqlEndpoint,
           }),
         };
       },

--- a/src/app/features/cart-view/payment/payment.component.ts
+++ b/src/app/features/cart-view/payment/payment.component.ts
@@ -23,12 +23,9 @@ export class PaymentComponent {
   constructor() { }
 
   completePayment(): void {
-    console.log('Payment completed using:', this.selectedPaymentMethod);
-    console.log('Card Number:', this.cardNumber);
-    console.log('Card Holder Name:', this.cardHolderName);
-    console.log('Expiry Date:', this.expiryDate);
-    console.log('CVV:', this.cvv);
-
+    // Raw card details (PAN, CVV, expiry) must never be logged or handled in the
+    // client. Integrate a PCI-compliant gateway (e.g. Stripe Elements, PayPal SDK)
+    // so card data is tokenized by the processor and never touches this code.
   }
 
 }

--- a/src/app/features/main-layout/footer/footer.component.ts
+++ b/src/app/features/main-layout/footer/footer.component.ts
@@ -11,7 +11,7 @@ export class FooterComponent {
   constructor(private router: Router) { }
 
   openLink(link: string) {
-    window.open(link);
+    window.open(link, '_blank', 'noopener,noreferrer');
   }
 
   toHome() {

--- a/src/app/features/products/Product.ts
+++ b/src/app/features/products/Product.ts
@@ -27,3 +27,35 @@ export interface Subcategory {
   id: number
   name: string
 }
+
+/**
+ * Runtime type guard for a Product. Used to validate untrusted data
+ * (e.g. values read back from localStorage) before it is trusted by the app.
+ */
+export function isProduct(value: unknown): value is Product {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate['id'] === 'number' &&
+    typeof candidate['name'] === 'string' &&
+    typeof candidate['price'] === 'number'
+  );
+}
+
+/**
+ * Safely parse a JSON string (e.g. from localStorage) into a Product array,
+ * discarding any entries that do not match the Product shape. Returns an empty
+ * array when the input is null/empty or is not a JSON array.
+ */
+export function parseStoredProducts(raw: string | null): Product[] {
+  if (!raw) {
+    return [];
+  }
+  const parsed: unknown = JSON.parse(raw);
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+  return parsed.filter(isProduct);
+}

--- a/src/app/shared/cart.service.ts
+++ b/src/app/shared/cart.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import {BehaviorSubject, map, Observable} from 'rxjs';
-import { Product } from '../features/products/Product';
+import { Product, parseStoredProducts } from '../features/products/Product';
 
 @Injectable({
   providedIn: 'root'
@@ -11,10 +11,7 @@ export class CartService {
 
   constructor() {
     try {
-      const cartItems = localStorage.getItem('cart');
-      if (cartItems) {
-        this.cartItems$.next(JSON.parse(cartItems));
-      }
+      this.cartItems$.next(parseStoredProducts(localStorage.getItem('cart')));
     } catch (error) {
       console.error('Failed to load cart items from localStorage:', error);
       this.cartItems$.next([]);

--- a/src/app/shared/wishlist.service.ts
+++ b/src/app/shared/wishlist.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { Product } from '../features/products/Product';
+import { Product, parseStoredProducts } from '../features/products/Product';
 
 @Injectable({
   providedIn: 'root'
@@ -11,10 +11,7 @@ export class WishlistService {
 
   constructor() {
     try {
-      const wishList = localStorage.getItem('wishlist');
-      if (wishList) {
-        this.wishListItems$.next(JSON.parse(wishList));
-      }
+      this.wishListItems$.next(parseStoredProducts(localStorage.getItem('wishlist')));
     } catch (error) {
       console.error('Failed to load wishlist items from localStorage:', error);
       this.wishListItems$.next([]);

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,13 @@
+// Public, non-secret runtime configuration.
+//
+// SECURITY: everything in this file is compiled into the browser bundle and is
+// publicly visible to anyone who loads the app. NEVER put secrets here or anywhere
+// in client-side code (no admin secrets, API keys, tokens, or passwords).
+//
+// The Hasura endpoint below is a public GraphQL URL. The browser sends NO
+// authorization header; the backend must expose the read-only catalog through a
+// Hasura "anonymous" role. See SECURITY.md for the required Hasura configuration.
+export const environment = {
+  production: false,
+  graphqlEndpoint: 'https://webshop.hasura.app/v1/graphql',
+};

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,6 @@
   <title>Webshop</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link href="https://unpkg.com/primeflex@^3/primeflex.css" rel="stylesheet">
   <link type="image/x-icon" href="favicon.ico" rel="icon">
 </head>
 


### PR DESCRIPTION
## Summary

Remediates findings from a security audit of the repository, in two rounds. Every change builds cleanly (`ng build --configuration production` → exit 0).

### Round 1 — low-risk, non-breaking fixes

| Severity | Finding | Fix | File |
|----------|---------|-----|------|
| 🟠 High | Full card number, **CVV**, expiry & cardholder name logged to console (PCI-DSS) | Removed the `console.log`s; guidance to use a tokenizing gateway | `payment.component.ts` |
| 🟢 Low | `window.open()` without `noopener,noreferrer` (reverse tabnabbing) | Added `'_blank', 'noopener,noreferrer'` | `footer.component.ts` |
| 🟢 Low | Unvalidated deserialization of `localStorage` | New `parseStoredProducts` / `isProduct` type guard, used on load | `Product.ts`, `cart.service.ts`, `wishlist.service.ts` |
| 🟢 Low | Third-party CSS from `unpkg` (floating version, no SRI) | Bundle `primeflex` from the local dependency | `angular.json`, `index.html` |

### Round 2 — Critical secret + hardening

| Severity | Finding | Fix | File |
|----------|---------|-----|------|
| 🔴 **Critical** | Hasura `x-hasura-admin-secret` hardcoded in the client bundle (full DB access to anyone) | Removed the admin-secret header; the browser now sends **no** auth header; endpoint moved to a config file | `app.module.ts`, `src/environments/environment.ts` |
| 📄 Docs | Backend hardening steps the maintainer must perform | Added `SECURITY.md` | `SECURITY.md` |
| ⚙️ CI | Stale Netlify site failing every PR | Added `netlify.toml` pinning build command / publish dir / Node version | `netlify.toml` |

The app is **read-only** against Hasura (catalog queries only, zero mutations), so the admin secret was never needed client-side.

## ⚠️ Action required by the maintainer

Removing the secret from source is necessary but not sufficient. On the Hasura side (full steps in `SECURITY.md`):

1. **Rotate the leaked admin secret immediately** — it is public in git history and in previously-shipped bundles, so treat it as fully compromised.
2. **Enable a read-only `anonymous` role** with `select`-only permission on `product` / `category` / `subcategory`, so the public catalog loads without any secret.
3. Restrict Hasura **CORS** to your origins and disable introspection in production.

Until step 2 is done, the deployed app still **builds and loads**, but catalog queries return "permission denied".

## Deferred (tracking issues)

- **#6** — Upgrade EOL Angular 15 / PrimeNG 15 (high-severity advisories). Requires a major, breaking migration that can't be verified in this CI environment; in-range `npm audit fix` does not address the core Angular CVEs.
- **#7** — Add authentication & authorization (none today; coupled to the Hasura role model).

## Verification

- `npm run build` (production) succeeds after every change; the bundle no longer contains the admin secret, and `primeflex` is compiled into the styles bundle instead of fetched from `unpkg`.
- TypeScript type-checks the new config import and the `Product` type guard.
- Karma/Cypress were not run here (no browser binary in the environment); the `localStorage` change only filters non-conforming entries and preserves valid `Product` objects (all mock data conforms).

https://claude.ai/code/session_01FVgAp6BwAjJo1SxLMamswn