### PR TITLE
test: repair broken specs and add missing unit coverage

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,35 +1,52 @@
 import { TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
+import { PrimeNGConfig } from 'primeng/api';
 import { AppComponent } from './app.component';
 
+/**
+ * These tests previously asserted the Angular CLI scaffold values — `title`
+ * equal to 'datastructures' and a "<title> app is running!" banner — both of
+ * which were removed long ago (the title is now 'Webshop' and the template only
+ * renders <app-header>/<router-outlet>/<app-footer>). They were red on every
+ * run. The assertions below match what the component actually does.
+ */
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        RouterTestingModule
-      ],
-      declarations: [
-        AppComponent
-      ],
+      imports: [RouterTestingModule],
+      declarations: [AppComponent],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   });
 
   it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
+    const app = TestBed.createComponent(AppComponent).componentInstance;
     expect(app).toBeTruthy();
   });
 
-  it(`should have as title 'datastructures'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('datastructures');
+  it(`should have as title 'Webshop'`, () => {
+    const app = TestBed.createComponent(AppComponent).componentInstance;
+    expect(app.title).toEqual('Webshop');
   });
 
-  it('should render title', () => {
+  it('enables PrimeNG ripple on init', () => {
+    const config = TestBed.inject(PrimeNGConfig);
+    config.ripple = false;
+
+    const app = TestBed.createComponent(AppComponent).componentInstance;
+    app.ngOnInit();
+
+    expect(config.ripple).toBeTrue();
+  });
+
+  it('renders the header, router outlet and footer shell', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('.content span')?.textContent).toContain('datastructures app is running!');
+
+    expect(compiled.querySelector('app-header')).not.toBeNull();
+    expect(compiled.querySelector('router-outlet')).not.toBeNull();
+    expect(compiled.querySelector('app-footer')).not.toBeNull();
   });
 });

--- a/src/app/features/cart-view/cart-item/cart-item.component.spec.ts
+++ b/src/app/features/cart-view/cart-item/cart-item.component.spec.ts
@@ -1,23 +1,91 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { CartItemComponent } from './cart-item.component';
+import { ProductImageService } from 'src/app/shared/product-image.service';
+import { createMockProduct } from 'src/app/testing/mock-data';
 
+/**
+ * The CLI stub failed at `detectChanges()` (NG0304: `p-button` unknown). It also
+ * never set the required `product` @Input, so the template would have dereferenced
+ * undefined. Here we mock ProductImageService, set a product, suppress the
+ * template with NO_ERRORS_SCHEMA, and cover the quantity/remove logic that drives
+ * the running cart total.
+ */
 describe('CartItemComponent', () => {
   let component: CartItemComponent;
   let fixture: ComponentFixture<CartItemComponent>;
+  let images: jasmine.SpyObj<ProductImageService>;
 
   beforeEach(async () => {
+    images = jasmine.createSpyObj('ProductImageService', [
+      'resolvePrimaryImage',
+      'handleImageError',
+    ]);
+    images.resolvePrimaryImage.and.returnValue('img.jpg');
+
     await TestBed.configureTestingModule({
-      declarations: [ CartItemComponent ]
-    })
-    .compileComponents();
+      declarations: [CartItemComponent],
+      providers: [{ provide: ProductImageService, useValue: images }],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(CartItemComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    component.product = createMockProduct({ id: 1, price: 100, inStock: 5 });
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('increments quantity (up to stock) and reports the price delta', () => {
+    const totalSpy = spyOn(component.updateCartTotal, 'emit');
+    component.incrementProductCount(5);
+    expect(component.pieces).toBe(2);
+    expect(totalSpy).toHaveBeenCalledWith(100);
+  });
+
+  it('does not increment beyond available stock', () => {
+    component.pieces = 5;
+    const totalSpy = spyOn(component.updateCartTotal, 'emit');
+    component.incrementProductCount(5);
+    expect(component.pieces).toBe(5);
+    expect(totalSpy).not.toHaveBeenCalled();
+  });
+
+  it('decrements quantity and reports the negative delta', () => {
+    component.pieces = 3;
+    const totalSpy = spyOn(component.updateCartTotal, 'emit');
+    component.decrementProductCount();
+    expect(component.pieces).toBe(2);
+    expect(totalSpy).toHaveBeenCalledWith(-100);
+  });
+
+  it('never decrements below 1', () => {
+    component.pieces = 1;
+    const totalSpy = spyOn(component.updateCartTotal, 'emit');
+    component.decrementProductCount();
+    expect(component.pieces).toBe(1);
+    expect(totalSpy).not.toHaveBeenCalled();
+  });
+
+  it('removeItem emits removeFromCart and subtracts the full line total', () => {
+    component.pieces = 3;
+    const removeSpy = spyOn(component.removeFromCart, 'emit');
+    const totalSpy = spyOn(component.updateCartTotal, 'emit');
+
+    component.removeItem(component.product);
+
+    expect(removeSpy).toHaveBeenCalledOnceWith(component.product);
+    expect(totalSpy).toHaveBeenCalledWith(-300); // price 100 * 3 pieces
+  });
+
+  it('getProductImage delegates to ProductImageService', () => {
+    expect(component.getProductImage(component.product)).toBe('img.jpg');
+    expect(images.resolvePrimaryImage).toHaveBeenCalledWith(
+      component.product.images,
+      component.product.name
+    );
   });
 });

--- a/src/app/features/cart-view/cart-view.component.spec.ts
+++ b/src/app/features/cart-view/cart-view.component.spec.ts
@@ -1,23 +1,65 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { Router } from '@angular/router';
+import { MessageService } from 'primeng/api';
 
 import { CartViewComponent } from './cart-view.component';
+import { CartService } from 'src/app/shared/cart.service';
+import { ProductImageService } from 'src/app/shared/product-image.service';
+import { of } from 'rxjs';
 
+/**
+ * The CLI stub threw `NullInjectorError: No provider for MessageService!`. We
+ * provide doubles for every dependency. ngOnInit wires several PrimeNG
+ * structures and subscriptions, so the smoke test stops at construction; the
+ * pure installment helper is covered directly.
+ */
 describe('CartViewComponent', () => {
   let component: CartViewComponent;
   let fixture: ComponentFixture<CartViewComponent>;
+  let cart: jasmine.SpyObj<CartService>;
+  let router: jasmine.SpyObj<Router>;
 
   beforeEach(async () => {
+    cart = jasmine.createSpyObj('CartService', ['getCartItems', 'removeFromCart']);
+    cart.getCartItems.and.returnValue(of([]));
+    router = jasmine.createSpyObj('Router', ['navigate']);
+
     await TestBed.configureTestingModule({
-      declarations: [ CartViewComponent ]
-    })
-    .compileComponents();
+      declarations: [CartViewComponent],
+      providers: [
+        { provide: CartService, useValue: cart },
+        { provide: Router, useValue: router },
+        { provide: ProductImageService, useValue: jasmine.createSpyObj('ProductImageService', ['resolvePrimaryImage', 'handleImageError']) },
+        MessageService,
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(CartViewComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    // Run ngOnInit so the cart/price subscriptions exist; otherwise the
+    // component's ngOnDestroy throws on `undefined.unsubscribe()` during teardown.
+    component.ngOnInit();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('getInstallmentPayAmount floors price / months', () => {
+    expect(component.getInstallmentPayAmount(1200, 12)).toBe(100);
+    expect(component.getInstallmentPayAmount(1000, 36)).toBe(27); // 27.7 -> 27
+  });
+
+  it('openShippingView toggles the label and navigates to the shipping route', () => {
+    component.openShippingView();
+    expect(component.shippingView).toBeTrue();
+    expect(component.shippingViewText).toBe('Back to cart view');
+    expect(router.navigate).toHaveBeenCalledWith(['cart/shipping']);
+
+    component.openShippingView();
+    expect(component.shippingView).toBeFalse();
+    expect(component.shippingViewText).toBe('Proceed with shipping');
   });
 });

--- a/src/app/features/cart-view/overview/overview.component.spec.ts
+++ b/src/app/features/cart-view/overview/overview.component.spec.ts
@@ -1,23 +1,43 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { of } from 'rxjs';
 
 import { OverviewComponent } from './overview.component';
+import { CartService } from 'src/app/shared/cart.service';
+import { mockProducts } from 'src/app/testing/mock-data';
 
+/**
+ * The CLI stub failed at `detectChanges()` (NG0304: `p-divider` unknown).
+ * OverviewComponent only reads the cart stream, so we provide a CartService
+ * double and assert it exposes those items.
+ */
 describe('OverviewComponent', () => {
   let component: OverviewComponent;
   let fixture: ComponentFixture<OverviewComponent>;
+  let cart: jasmine.SpyObj<CartService>;
 
   beforeEach(async () => {
+    cart = jasmine.createSpyObj('CartService', ['getCartItems']);
+    cart.getCartItems.and.returnValue(of([mockProducts[0], mockProducts[1]]));
+
     await TestBed.configureTestingModule({
-      declarations: [ OverviewComponent ]
-    })
-    .compileComponents();
+      declarations: [OverviewComponent],
+      providers: [{ provide: CartService, useValue: cart }],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(OverviewComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('exposes the cart items stream from CartService', (done) => {
+    component.products$.subscribe((items) => {
+      expect(items).toEqual([mockProducts[0], mockProducts[1]]);
+      done();
+    });
   });
 });

--- a/src/app/features/cart-view/payment/payment.component.spec.ts
+++ b/src/app/features/cart-view/payment/payment.component.spec.ts
@@ -1,0 +1,45 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+
+import { PaymentComponent } from './payment.component';
+
+/**
+ * PaymentComponent — the checkout payment step — previously had NO spec at all
+ * (zero coverage on a critical path). It has no injected dependencies. We stop
+ * at construction (the PrimeNG `[(ngModel)]` form controls have no value
+ * accessor under a unit harness) and cover the `total` getter and submit handler
+ * directly.
+ */
+describe('PaymentComponent', () => {
+  let component: PaymentComponent;
+  let fixture: ComponentFixture<PaymentComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PaymentComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PaymentComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('total sums subtotal and shipping', () => {
+    component.subtotal = 100;
+    component.shipping = 10;
+    expect(component.total).toBe(110);
+
+    component.subtotal = 250;
+    component.shipping = 0;
+    expect(component.total).toBe(250);
+  });
+
+  it('completePayment runs for the selected method without throwing', () => {
+    component.selectedPaymentMethod = 'paypal';
+    expect(() => component.completePayment()).not.toThrow();
+  });
+});

--- a/src/app/features/cart-view/shipping/shipping.component.spec.ts
+++ b/src/app/features/cart-view/shipping/shipping.component.spec.ts
@@ -1,23 +1,32 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 
 import { ShippingComponent } from './shipping.component';
 
+/**
+ * The CLI stub failed at `detectChanges()`: the template uses `[(ngModel)]`
+ * (needs FormsModule) and PrimeNG elements (`p-divider`, `p-checkbox`). With
+ * FormsModule imported and NO_ERRORS_SCHEMA suppressing the PrimeNG tags, the
+ * presentational form renders cleanly.
+ */
 describe('ShippingComponent', () => {
   let component: ShippingComponent;
   let fixture: ComponentFixture<ShippingComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ ShippingComponent ]
-    })
-    .compileComponents();
+      imports: [FormsModule],
+      declarations: [ShippingComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ShippingComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should create and render the shipping form', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 });

--- a/src/app/features/home/home.component.spec.ts
+++ b/src/app/features/home/home.component.spec.ts
@@ -1,23 +1,63 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
 
 import { HomeComponent } from './home.component';
+import { ProductsService } from '../products/products.service';
+import { ProductImageService } from 'src/app/shared/product-image.service';
+import { mockProducts } from 'src/app/testing/mock-data';
 
+/**
+ * The CLI stub threw `No provider for Apollo!` via ProductsService. With doubles
+ * for ProductsService / ProductImageService / Router we cover ngOnInit's
+ * suggested-products mapping and the redirect helper.
+ */
 describe('HomeComponent', () => {
   let component: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
+  let products: jasmine.SpyObj<ProductsService>;
+  let images: jasmine.SpyObj<ProductImageService>;
+  let router: jasmine.SpyObj<Router>;
 
   beforeEach(async () => {
+    products = jasmine.createSpyObj('ProductsService', ['getSuggestedProducts']);
+    products.getSuggestedProducts.and.returnValue(
+      of({ data: { product: [mockProducts[0]] } }) as any
+    );
+    images = jasmine.createSpyObj('ProductImageService', ['normalizeImages']);
+    images.normalizeImages.and.returnValue(['normalized.jpg', 'fallback.jpg']);
+    router = jasmine.createSpyObj('Router', ['navigate']);
+
     await TestBed.configureTestingModule({
-      declarations: [ HomeComponent ]
-    })
-    .compileComponents();
+      declarations: [HomeComponent],
+      providers: [
+        { provide: ProductsService, useValue: products },
+        { provide: ProductImageService, useValue: images },
+        { provide: Router, useValue: router },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    // Initialise so the `suggestedProductsSubscription` exists; otherwise the
+    // component's ngOnDestroy throws on `undefined.unsubscribe()` during teardown.
+    component.ngOnInit();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('ngOnInit maps suggested products through ProductImageService.normalizeImages', () => {
+    expect(component.suggestedProducts.length).toBe(1);
+    expect(component.suggestedProducts[0].images).toEqual(['normalized.jpg', 'fallback.jpg']);
+    expect(images.normalizeImages).toHaveBeenCalled();
+  });
+
+  it('redirect navigates to the product details route', () => {
+    component.redirect(4);
+    expect(router.navigate).toHaveBeenCalledWith(['/product', 4]);
   });
 });

--- a/src/app/features/home/suggested-product/suggested-product.component.spec.ts
+++ b/src/app/features/home/suggested-product/suggested-product.component.spec.ts
@@ -1,23 +1,52 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { SuggestedProductComponent } from './suggested-product.component';
+import { ProductImageService } from 'src/app/shared/product-image.service';
 
 describe('SuggestedProductComponent', () => {
   let component: SuggestedProductComponent;
   let fixture: ComponentFixture<SuggestedProductComponent>;
+  let images: jasmine.SpyObj<ProductImageService>;
 
   beforeEach(async () => {
+    images = jasmine.createSpyObj('ProductImageService', [
+      'resolvePrimaryImage',
+      'handleImageError',
+    ]);
+    images.resolvePrimaryImage.and.returnValue('resolved.jpg');
+
     await TestBed.configureTestingModule({
-      declarations: [ SuggestedProductComponent ]
-    })
-    .compileComponents();
+      declarations: [SuggestedProductComponent],
+      providers: [{ provide: ProductImageService, useValue: images }],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(SuggestedProductComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    component.id = 3;
+    component.name = 'iPad Pro';
+    component.image = 'ipad.jpg';
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('openDetails emits the product id', () => {
+    const emitSpy = spyOn(component.openProductDetails, 'emit');
+    component.openDetails(3);
+    expect(emitSpy).toHaveBeenCalledOnceWith(3);
+  });
+
+  it('resolvedImage resolves the single image through ProductImageService', () => {
+    expect(component.resolvedImage).toBe('resolved.jpg');
+    expect(images.resolvePrimaryImage).toHaveBeenCalledWith(['ipad.jpg'], 'iPad Pro');
+  });
+
+  it('onImageError delegates to ProductImageService', () => {
+    const event = new Event('error');
+    component.onImageError(event);
+    expect(images.handleImageError).toHaveBeenCalledWith(event, 'iPad Pro');
   });
 });

--- a/src/app/features/main-layout/footer/footer.component.spec.ts
+++ b/src/app/features/main-layout/footer/footer.component.spec.ts
@@ -1,23 +1,45 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { Router } from '@angular/router';
 
 import { FooterComponent } from './footer.component';
 
+/**
+ * The CLI stub failed at `detectChanges()` with NG0303 (`routerLink` is not a
+ * known property) because no router was provided. Here we inject a Router spy,
+ * suppress the PrimeNG/router template with NO_ERRORS_SCHEMA, and additionally
+ * cover the two real methods.
+ */
 describe('FooterComponent', () => {
   let component: FooterComponent;
   let fixture: ComponentFixture<FooterComponent>;
+  let router: jasmine.SpyObj<Router>;
 
   beforeEach(async () => {
+    router = jasmine.createSpyObj('Router', ['navigate']);
+
     await TestBed.configureTestingModule({
-      declarations: [ FooterComponent ]
-    })
-    .compileComponents();
+      declarations: [FooterComponent],
+      providers: [{ provide: Router, useValue: router }],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(FooterComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('toHome navigates to /home', () => {
+    component.toHome();
+    expect(router.navigate).toHaveBeenCalledWith(['/home']);
+  });
+
+  it('openLink opens the given URL in a new window', () => {
+    const openSpy = spyOn(window, 'open');
+    component.openLink('https://github.com/golubovicluka');
+    expect(openSpy).toHaveBeenCalledWith('https://github.com/golubovicluka');
   });
 });

--- a/src/app/features/main-layout/header/header.component.spec.ts
+++ b/src/app/features/main-layout/header/header.component.spec.ts
@@ -1,23 +1,58 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { Router } from '@angular/router';
 
 import { HeaderComponent } from './header.component';
+import { WishlistService } from 'src/app/shared/wishlist.service';
+import { CartService } from 'src/app/shared/cart.service';
+import { of } from 'rxjs';
+import { mockProducts } from 'src/app/testing/mock-data';
 
+/**
+ * The CLI stub failed at `detectChanges()` (NG0304: `p-slideMenu` unknown) and
+ * would also have failed DI on Router. We provide doubles for all three
+ * dependencies and cover the counter wiring plus the active-route check.
+ */
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
+  let wishlist: jasmine.SpyObj<WishlistService>;
+  let cart: jasmine.SpyObj<CartService>;
+  let router: { url: string };
 
   beforeEach(async () => {
+    wishlist = jasmine.createSpyObj('WishlistService', ['getWishListItems']);
+    cart = jasmine.createSpyObj('CartService', ['getCartItems']);
+    wishlist.getWishListItems.and.returnValue(of([mockProducts[0]]));
+    cart.getCartItems.and.returnValue(of([mockProducts[0], mockProducts[1]]));
+    router = { url: '/home' };
+
     await TestBed.configureTestingModule({
-      declarations: [ HeaderComponent ]
-    })
-    .compileComponents();
+      declarations: [HeaderComponent],
+      providers: [
+        { provide: WishlistService, useValue: wishlist },
+        { provide: CartService, useValue: cart },
+        { provide: Router, useValue: router },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(HeaderComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('ngOnInit reflects wishlist and cart counts as strings', () => {
+    component.ngOnInit();
+    expect(component.wishListItems).toBe('1');
+    expect(component.cartItems).toBe('2');
+  });
+
+  it('isActiveRoute matches the current router url', () => {
+    expect(component.isActiveRoute('/home')).toBeTrue();
+    expect(component.isActiveRoute('/cart')).toBeFalse();
   });
 });

--- a/src/app/features/products/categories-view/categories-view.component.spec.ts
+++ b/src/app/features/products/categories-view/categories-view.component.spec.ts
@@ -1,23 +1,58 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
 
 import { CategoriesViewComponent } from './categories-view.component';
+import { ProductsService } from '../products.service';
+import { mockCategoriesWithSubcategories } from 'src/app/testing/mock-data';
 
+/**
+ * The CLI stub threw `No provider for Apollo!` via ProductsService. We swap in a
+ * ProductsService double (so no Apollo graph is needed) and a Router spy, then
+ * cover ngOnInit and the navigation/filter handoff.
+ */
 describe('CategoriesViewComponent', () => {
   let component: CategoriesViewComponent;
   let fixture: ComponentFixture<CategoriesViewComponent>;
+  let products: jasmine.SpyObj<ProductsService>;
+  let router: jasmine.SpyObj<Router>;
 
   beforeEach(async () => {
+    products = jasmine.createSpyObj('ProductsService', ['getProductCategories', 'setCategoryFilter']);
+    products.getProductCategories.and.returnValue(
+      of({ data: { category: mockCategoriesWithSubcategories } }) as any
+    );
+    router = jasmine.createSpyObj('Router', ['navigate']);
+
     await TestBed.configureTestingModule({
-      declarations: [ CategoriesViewComponent ]
-    })
-    .compileComponents();
+      declarations: [CategoriesViewComponent],
+      providers: [
+        { provide: ProductsService, useValue: products },
+        { provide: Router, useValue: router },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(CategoriesViewComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('ngOnInit loads categories from the service', () => {
+    component.ngOnInit();
+    expect(component.categories).toEqual(mockCategoriesWithSubcategories);
+  });
+
+  it('openProductsPage sets the category filter and navigates with state', () => {
+    component.openProductsPage('Electronics');
+    expect(products.setCategoryFilter).toHaveBeenCalledOnceWith('Electronics');
+    expect(router.navigate).toHaveBeenCalledWith(
+      ['/products/search'],
+      jasmine.objectContaining({ state: { filters: 'Electronics' } })
+    );
   });
 });

--- a/src/app/features/products/categories-view/category/category.component.spec.ts
+++ b/src/app/features/products/categories-view/category/category.component.spec.ts
@@ -1,23 +1,44 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { CategoryComponent } from './category.component';
 
+/**
+ * CategoryComponent is presentational (no injected services), so the original
+ * stub already constructed fine — but it asserted nothing beyond truthiness.
+ * Added: the @Output emit and the category->image mapping (including the
+ * unmapped default).
+ */
 describe('CategoryComponent', () => {
   let component: CategoryComponent;
   let fixture: ComponentFixture<CategoryComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ CategoryComponent ]
-    })
-    .compileComponents();
+      declarations: [CategoryComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(CategoryComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('openProductsPage emits the category name', () => {
+    const emitSpy = spyOn(component.applyCategoryFilter, 'emit');
+    component.openProductsPage('Electronics');
+    expect(emitSpy).toHaveBeenCalledOnceWith('Electronics');
+  });
+
+  it('getCategoryImage returns a mapped image for known categories', () => {
+    expect(component.getCategoryImage('Electronics')).toContain('http');
+    expect(component.getCategoryImage('Kitchen')).toContain('http');
+  });
+
+  it('getCategoryImage returns undefined for unmapped categories', () => {
+    expect(component.getCategoryImage('Totally Unknown Category')).toBeUndefined();
   });
 });

--- a/src/app/features/products/filters/filters.component.spec.ts
+++ b/src/app/features/products/filters/filters.component.spec.ts
@@ -1,23 +1,37 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ApolloTestingModule } from 'apollo-angular/testing';
 
 import { FiltersComponent } from './filters.component';
 
+/**
+ * FiltersComponent injects ProductsService, which depends on Apollo. The CLI
+ * stub provided neither, so it threw `No provider for Apollo!`. ApolloTestingModule
+ * satisfies that graph; we additionally cover the filter event emitter.
+ */
 describe('FiltersComponent', () => {
   let component: FiltersComponent;
   let fixture: ComponentFixture<FiltersComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ FiltersComponent ]
-    })
-    .compileComponents();
+      imports: [ApolloTestingModule],
+      declarations: [FiltersComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(FiltersComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('changeFilter forwards the selected filter object to subscribers', () => {
+    const emitSpy = spyOn(component.filtersObject, 'emit');
+    const payload = ['Smartphones', 'Laptops'];
+    component.changeFilter(payload);
+    expect(emitSpy).toHaveBeenCalledOnceWith(payload);
   });
 });

--- a/src/app/features/products/product/product-details/product-details.component.spec.ts
+++ b/src/app/features/products/product/product-details/product-details.component.spec.ts
@@ -1,23 +1,88 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Location } from '@angular/common';
+import { MessageService } from 'primeng/api';
 
 import { ProductDetailsComponent } from './product-details.component';
+import { ProductsService } from '../../products.service';
+import { WishlistService } from 'src/app/shared/wishlist.service';
+import { CartService } from 'src/app/shared/cart.service';
+import { ProductImageService } from 'src/app/shared/product-image.service';
+import { mockProducts } from 'src/app/testing/mock-data';
 
+/**
+ * The CLI stub threw `No provider for Apollo!` via ProductsService and also
+ * needed Router/ActivatedRoute/Location/MessageService. The constructor reads
+ * `router.getCurrentNavigation()`, so that spy returns null (the "navigated
+ * directly / reloaded" path). Covered: construction, the installment helper, the
+ * cart handoffs, and back-navigation.
+ */
 describe('ProductDetailsComponent', () => {
   let component: ProductDetailsComponent;
   let fixture: ComponentFixture<ProductDetailsComponent>;
+  let cart: jasmine.SpyObj<CartService>;
+  let location: jasmine.SpyObj<Location>;
+  let router: jasmine.SpyObj<Router>;
 
   beforeEach(async () => {
+    const products = jasmine.createSpyObj('ProductsService', [
+      'getProductById',
+      'getProductsByCategory',
+    ]);
+    const wishlist = jasmine.createSpyObj('WishlistService', [
+      'inWishlist',
+      'addWishListItem',
+      'removeWishListItem',
+    ]);
+    cart = jasmine.createSpyObj('CartService', ['addToCart', 'removeFromCart']);
+    const images = jasmine.createSpyObj('ProductImageService', [
+      'normalizeImages',
+      'resolvePrimaryImage',
+      'handleImageError',
+    ]);
+    location = jasmine.createSpyObj('Location', ['back']);
+    router = jasmine.createSpyObj('Router', ['navigate', 'getCurrentNavigation']);
+    router.getCurrentNavigation.and.returnValue(null);
+
     await TestBed.configureTestingModule({
-      declarations: [ ProductDetailsComponent ]
-    })
-    .compileComponents();
+      declarations: [ProductDetailsComponent],
+      providers: [
+        { provide: ProductsService, useValue: products },
+        { provide: WishlistService, useValue: wishlist },
+        { provide: CartService, useValue: cart },
+        { provide: ProductImageService, useValue: images },
+        { provide: Location, useValue: location },
+        { provide: Router, useValue: router },
+        { provide: ActivatedRoute, useValue: { snapshot: { params: { id: 1 } } } },
+        MessageService,
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ProductDetailsComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('getInstallmentPayAmount floors price / months', () => {
+    expect(component.getInstallmentPayAmount(1200, 12)).toBe(100);
+    expect(component.getInstallmentPayAmount(1000, 24)).toBe(41); // 41.6 -> 41
+  });
+
+  it('navigateBack uses Location.back', () => {
+    component.navigateBack();
+    expect(location.back).toHaveBeenCalled();
+  });
+
+  it('addToCart / removeFromCart delegate to CartService', () => {
+    component.addToCart(mockProducts[0]);
+    expect(cart.addToCart).toHaveBeenCalledOnceWith(mockProducts[0]);
+
+    component.removeFromCart(mockProducts[0]);
+    expect(cart.removeFromCart).toHaveBeenCalledOnceWith(mockProducts[0]);
   });
 });

--- a/src/app/features/products/product/product.component.spec.ts
+++ b/src/app/features/products/product/product.component.spec.ts
@@ -1,23 +1,210 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { Router, ActivatedRoute } from '@angular/router';
+import { MessageService } from 'primeng/api';
 
 import { ProductComponent } from './product.component';
+import { WishlistService } from 'src/app/shared/wishlist.service';
+import { CartService } from 'src/app/shared/cart.service';
+import { ProductImageService } from 'src/app/shared/product-image.service';
+import { createMockProduct } from 'src/app/testing/mock-data';
 
+/**
+ * The original spec was the Angular CLI stub: it declared ProductComponent with
+ * no providers and asserted only `toBeTruthy()`. Because the component injects
+ * MessageService / Router / ActivatedRoute (none `providedIn: 'root'`) it threw
+ * `NullInjectorError: No provider for MessageService!` and never ran.
+ *
+ * This rewrite provides test doubles for every dependency and covers the actual
+ * behaviour: the wishlist/cart toggles (state flip + correct @Output + the
+ * right PrimeNG toast), the installment maths, the route-dependent branch in
+ * `openProductDetails`, and the image getter. Logic is driven by calling methods
+ * directly rather than asserting on the PrimeNG template, so the tests don't
+ * break when markup/classes change.
+ */
 describe('ProductComponent', () => {
   let component: ProductComponent;
   let fixture: ComponentFixture<ProductComponent>;
 
+  let wishlist: jasmine.SpyObj<WishlistService>;
+  let cart: jasmine.SpyObj<CartService>;
+  let images: jasmine.SpyObj<ProductImageService>;
+  let messages: jasmine.SpyObj<MessageService>;
+  let router: jasmine.SpyObj<Router>;
+  let route: { snapshot: { url: string[] } };
+
   beforeEach(async () => {
+    wishlist = jasmine.createSpyObj('WishlistService', [
+      'inWishlist',
+      'addWishListItem',
+      'removeWishListItem',
+    ]);
+    cart = jasmine.createSpyObj('CartService', ['inCart', 'addToCart', 'removeFromCart']);
+    images = jasmine.createSpyObj('ProductImageService', [
+      'normalizeImages',
+      'resolvePrimaryImage',
+      'handleImageError',
+    ]);
+    messages = jasmine.createSpyObj('MessageService', ['add']);
+    router = jasmine.createSpyObj('Router', ['navigate']);
+    route = { snapshot: { url: ['products', 'search'] } };
+
+    wishlist.inWishlist.and.returnValue(false);
+    cart.inCart.and.returnValue(false);
+    images.normalizeImages.and.returnValue(['primary.jpg', 'secondary.jpg']);
+    images.resolvePrimaryImage.and.returnValue('primary.jpg');
+
     await TestBed.configureTestingModule({
-      declarations: [ ProductComponent ]
-    })
-    .compileComponents();
+      declarations: [ProductComponent],
+      providers: [
+        { provide: WishlistService, useValue: wishlist },
+        { provide: CartService, useValue: cart },
+        { provide: ProductImageService, useValue: images },
+        { provide: MessageService, useValue: messages },
+        { provide: Router, useValue: router },
+        { provide: ActivatedRoute, useValue: route },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ProductComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    component.id = 1;
+    component.name = 'iPhone 13 Pro';
+    component.price = 1200;
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('ngOnInit', () => {
+    it('normalizes images and assembles the product from @Input fields', () => {
+      component.description = 'Desc';
+      component.images = ['raw.jpg'];
+
+      component.ngOnInit();
+
+      expect(images.normalizeImages).toHaveBeenCalledWith(['raw.jpg'], 'iPhone 13 Pro');
+      expect(component.images).toEqual(['primary.jpg', 'secondary.jpg']);
+      expect(component.product).toEqual(
+        jasmine.objectContaining({ id: 1, name: 'iPhone 13 Pro', price: 1200 })
+      );
+    });
+
+    it('reflects the services current wishlist/cart membership', () => {
+      wishlist.inWishlist.and.returnValue(true);
+      cart.inCart.and.returnValue(true);
+
+      component.ngOnInit();
+
+      expect(component.inWishlist).toBeTrue();
+      expect(component.inCart).toBeTrue();
+    });
+  });
+
+  describe('addRemoveItemWishlist', () => {
+    it('adds: flips state on, emits addedToWishList and shows a success toast', () => {
+      const product = createMockProduct({ id: 1 });
+      component.inWishlist = false;
+      const addedSpy = spyOn(component.addedToWishList, 'emit');
+
+      component.addRemoveItemWishlist(product);
+
+      expect(component.inWishlist).toBeTrue();
+      expect(addedSpy).toHaveBeenCalledOnceWith(product);
+      expect(messages.add).toHaveBeenCalledWith(
+        jasmine.objectContaining({ severity: 'success', detail: 'Added to wishlist' })
+      );
+    });
+
+    it('removes: flips state off, emits removedFromWishList and shows an info toast', () => {
+      const product = createMockProduct({ id: 1 });
+      component.inWishlist = true;
+      const removedSpy = spyOn(component.removedFromWishList, 'emit');
+
+      component.addRemoveItemWishlist(product);
+
+      expect(component.inWishlist).toBeFalse();
+      expect(removedSpy).toHaveBeenCalledOnceWith(product);
+      expect(messages.add).toHaveBeenCalledWith(
+        jasmine.objectContaining({ severity: 'info', detail: 'Removed from wishlist' })
+      );
+    });
+  });
+
+  describe('addRemoveCartItem', () => {
+    it('adds to cart: flips state on, emits addedToCart and shows a success toast', () => {
+      const product = createMockProduct({ id: 1 });
+      component.inCart = false;
+      const addedSpy = spyOn(component.addedToCart, 'emit');
+
+      component.addRemoveCartItem(product);
+
+      expect(component.inCart).toBeTrue();
+      expect(addedSpy).toHaveBeenCalledOnceWith(product);
+      expect(messages.add).toHaveBeenCalledWith(
+        jasmine.objectContaining({ severity: 'success', detail: 'Added to cart' })
+      );
+    });
+
+    it('removes from cart: flips state off and emits removedFromCart', () => {
+      const product = createMockProduct({ id: 1 });
+      component.inCart = true;
+      const removedSpy = spyOn(component.removedFromCart, 'emit');
+
+      component.addRemoveCartItem(product);
+
+      expect(component.inCart).toBeFalse();
+      expect(removedSpy).toHaveBeenCalledOnceWith(product);
+    });
+  });
+
+  describe('getInstallmentPayAmount', () => {
+    it('floors price / 12', () => {
+      expect(component.getInstallmentPayAmount(1200)).toBe(100);
+      expect(component.getInstallmentPayAmount(1250)).toBe(104); // 104.16 -> 104
+      expect(component.getInstallmentPayAmount(0)).toBe(0);
+    });
+  });
+
+  describe('openProductDetails', () => {
+    it('navigates with product state when already on a products route', () => {
+      component.ngOnInit(); // builds component.product
+      route.snapshot.url = ['products', 'search'];
+
+      component.openProductDetails(42);
+
+      expect(router.navigate).toHaveBeenCalledWith(
+        ['/product', 42],
+        jasmine.objectContaining({ state: { product: component.product } })
+      );
+    });
+
+    it('emits replaceCurrentProduct and scrolls up when not on a products route', () => {
+      const replaceSpy = spyOn(component.replaceCurrentProduct, 'emit');
+      const scrollSpy = spyOn(window, 'scrollTo');
+      route.snapshot.url = ['home'];
+
+      component.openProductDetails(7);
+
+      expect(replaceSpy).toHaveBeenCalledOnceWith(7);
+      expect(scrollSpy).toHaveBeenCalled();
+      expect(router.navigate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('image helpers', () => {
+    it('primaryImageSrc delegates to ProductImageService.resolvePrimaryImage', () => {
+      component.images = ['a.jpg'];
+      expect(component.primaryImageSrc).toBe('primary.jpg');
+      expect(images.resolvePrimaryImage).toHaveBeenCalledWith(['a.jpg'], 'iPhone 13 Pro');
+    });
+
+    it('onImageError delegates to ProductImageService.handleImageError', () => {
+      const event = new Event('error');
+      component.onImageError(event);
+      expect(images.handleImageError).toHaveBeenCalledWith(event, 'iPhone 13 Pro');
+    });
   });
 });

--- a/src/app/features/products/products-view.component.spec.ts
+++ b/src/app/features/products/products-view.component.spec.ts
@@ -1,23 +1,85 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MessageService } from 'primeng/api';
 
 import { ProductsViewComponent } from './products-view.component';
+import { ProductsService } from './products.service';
+import { WishlistService } from '../../shared/wishlist.service';
+import { CartService } from 'src/app/shared/cart.service';
+import { mockProducts } from 'src/app/testing/mock-data';
 
+/**
+ * The CLI stub threw `No provider for Apollo!` via ProductsService. This is the
+ * most logic-heavy component in the app; ngOnInit fires multiple queries and a
+ * large PrimeNG template, so the smoke test stops at construction (the
+ * constructor reads `router.getCurrentNavigation()`, hence the Router spy).
+ * Dependency-light behaviour — the trackBy and the wishlist/cart handoffs — is
+ * covered directly.
+ */
 describe('ProductsViewComponent', () => {
   let component: ProductsViewComponent;
   let fixture: ComponentFixture<ProductsViewComponent>;
+  let wishlist: jasmine.SpyObj<WishlistService>;
+  let cart: jasmine.SpyObj<CartService>;
+  let router: jasmine.SpyObj<Router>;
 
   beforeEach(async () => {
+    const products = jasmine.createSpyObj('ProductsService', [
+      'getProducts',
+      'getProductCategories',
+      'searchProducts',
+      'getFilteredProducts',
+      'getProductsByPrice',
+    ]);
+    wishlist = jasmine.createSpyObj('WishlistService', ['addWishListItem', 'removeWishListItem']);
+    cart = jasmine.createSpyObj('CartService', ['addToCart', 'removeFromCart']);
+    router = jasmine.createSpyObj('Router', ['navigate', 'getCurrentNavigation']);
+    router.getCurrentNavigation.and.returnValue(null);
+
     await TestBed.configureTestingModule({
-      declarations: [ProductsViewComponent]
-    })
-      .compileComponents();
+      declarations: [ProductsViewComponent],
+      providers: [
+        { provide: ProductsService, useValue: products },
+        { provide: WishlistService, useValue: wishlist },
+        { provide: CartService, useValue: cart },
+        { provide: Router, useValue: router },
+        { provide: ActivatedRoute, useValue: { snapshot: { params: {} } } },
+        MessageService,
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ProductsViewComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('trackByProductId returns the product id', () => {
+    expect(component.trackByProductId(0, mockProducts[2])).toBe(mockProducts[2].id);
+  });
+
+  it('addToWishList / removedFromWishList delegate to WishlistService', () => {
+    component.addToWishList(mockProducts[0]);
+    expect(wishlist.addWishListItem).toHaveBeenCalledOnceWith(mockProducts[0]);
+
+    component.removedFromWishList(mockProducts[0]);
+    expect(wishlist.removeWishListItem).toHaveBeenCalledOnceWith(mockProducts[0]);
+  });
+
+  it('addToCart / removeFromCart delegate to CartService', () => {
+    component.addToCart(mockProducts[1]);
+    expect(cart.addToCart).toHaveBeenCalledOnceWith(mockProducts[1]);
+
+    component.removeFromCart(mockProducts[1]);
+    expect(cart.removeFromCart).toHaveBeenCalledOnceWith(mockProducts[1]);
+  });
+
+  it('openProductDetails navigates to the product route', () => {
+    component.openProductDetails(9);
+    expect(router.navigate).toHaveBeenCalledWith(['/product', 9]);
   });
 });

--- a/src/app/features/products/products.service.spec.ts
+++ b/src/app/features/products/products.service.spec.ts
@@ -1,422 +1,272 @@
 import { TestBed } from '@angular/core/testing';
+import { ApolloTestingModule, ApolloTestingController } from 'apollo-angular/testing';
 import { ProductsService } from './products.service';
-import { Apollo } from 'apollo-angular';
+import { Product } from './Product';
 import { mockProducts, mockProduct, mockCategoriesWithSubcategories } from '../../testing/mock-data';
-import { createMockWatchQueryResponse } from '../../testing/apollo-mock';
 
+/**
+ * Apollo's test cache adds `__typename` to every selection, so a flushed payload
+ * must carry `__typename` or the cache returns hollow ({}) objects on read.
+ * This annotates a fixture (and its nested entities) for flushing; Apollo strips
+ * `__typename` again on read, so the emitted value still deep-equals the fixture.
+ */
+function asGql(product: Product) {
+  return {
+    __typename: 'product',
+    ...product,
+    category: product.category ? { __typename: 'category', ...product.category } : product.category,
+    subcategory: product.subcategory
+      ? { __typename: 'subcategory', ...product.subcategory }
+      : product.subcategory,
+  };
+}
+
+/**
+ * ProductsService talks to a Hasura GraphQL backend through Apollo. The previous
+ * version of this spec replaced Apollo with a hand-rolled `watchQuery` spy. That
+ * approach had three problems:
+ *
+ *   1. It never validated the GraphQL documents the service builds, so a broken
+ *      query, a renamed variable, or a wrong operation would still "pass".
+ *   2. The mock double-wrapped the payload (`{ data: { data: { product } } }`),
+ *      so every `result.data.product` assertion silently compared against
+ *      `undefined` — the assertions were effectively dead. (See git history:
+ *      ~18 of these tests were red.)
+ *   3. Subscriptions were never completed/unsubscribed, leaking a callback that
+ *      threw inside `afterAll` and disconnected the Karma browser.
+ *
+ * This version uses ApolloTestingModule so we exercise the real Apollo links:
+ * the service emits a request, we assert on the *actual* operation name and
+ * variables, then flush a controlled response (or a network error). `verify()`
+ * fails the test if the service issues an unexpected query. Emissions arrive
+ * asynchronously, so each test uses the `done` callback.
+ */
 describe('ProductsService', () => {
   let service: ProductsService;
-  let apolloSpy: jasmine.SpyObj<Apollo>;
+  let controller: ApolloTestingController;
 
   beforeEach(() => {
-    apolloSpy = jasmine.createSpyObj('Apollo', ['watchQuery']);
-
     TestBed.configureTestingModule({
-      providers: [
-        ProductsService,
-        { provide: Apollo, useValue: apolloSpy }
-      ]
+      imports: [ApolloTestingModule],
+      providers: [ProductsService],
     });
-
     service = TestBed.inject(ProductsService);
+    controller = TestBed.inject(ApolloTestingController);
+  });
+
+  afterEach(() => {
+    // Fails if any query was issued that a test did not explicitly expect/flush.
+    controller.verify();
   });
 
   describe('Initialization', () => {
     it('should be created', () => {
       expect(service).toBeTruthy();
     });
-
-    it('should have categoryFilter$ subject', () => {
-      expect(service.categoryFilter$).toBeDefined();
-    });
-
-    it('should have categoryFilter observable', () => {
-      expect(service.categoryFilter).toBeDefined();
-    });
   });
 
   describe('setCategoryFilter', () => {
-    it('should emit category filter value', (done) => {
-      const category = 'Electronics';
+    it('emits the category on the categoryFilter stream', (done) => {
+      service.categoryFilter.subscribe((value) => {
+        expect(value).toBe('Electronics');
+        done();
+      });
+      service.setCategoryFilter('Electronics');
+    });
 
-      service.categoryFilter.subscribe(value => {
-        expect(value).toBe(category);
+    it('emits every pushed category in order', () => {
+      const received: string[] = [];
+      service.categoryFilter.subscribe((v) => received.push(v));
+
+      ['Electronics', 'Clothing', 'Home & Garden'].forEach((c) => service.setCategoryFilter(c));
+
+      expect(received).toEqual(['Electronics', 'Clothing', 'Home & Garden']);
+    });
+  });
+
+  describe('getProducts (query selection by arguments)', () => {
+    it('uses GetProducts with category + sortBy when both are provided', (done) => {
+      service.getProducts('desc', 'Electronics').subscribe((r: any) => {
+        expect(r.data.product).toEqual([mockProducts[0]]);
         done();
       });
 
-      service.setCategoryFilter(category);
+      const op = controller.expectOne('GetProducts');
+      expect(op.operation.variables).toEqual({ category: 'Electronics', sortBy: 'desc' });
+      op.flushData({ product: [asGql(mockProducts[0])] });
     });
 
-    it('should emit multiple category filter values', (done) => {
-      const categories = ['Electronics', 'Clothing', 'Home & Garden'];
-      let index = 0;
+    it('uses GetProductsByCategory when only a category is provided', (done) => {
+      service.getProducts(undefined, 'Electronics').subscribe(() => done());
 
-      service.categoryFilter.subscribe(value => {
-        expect(value).toBe(categories[index]);
-        index++;
-        if (index === categories.length) {
-          done();
-        }
-      });
-
-      categories.forEach(cat => service.setCategoryFilter(cat));
-    });
-  });
-
-  describe('getProducts', () => {
-    it('should get all products without filters', () => {
-      const mockResponse = { data: { product: mockProducts } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
-
-      const result$ = service.getProducts();
-
-      result$.subscribe((result: any) => {
-        expect(result.data.product).toEqual(mockProducts);
-      });
-
-      expect(apolloSpy.watchQuery).toHaveBeenCalled();
+      const op = controller.expectOne('GetProductsByCategory');
+      expect(op.operation.variables).toEqual({ category: 'Electronics' });
+      op.flushData({ product: [] });
     });
 
-    it('should get products with category filter', () => {
-      const mockResponse = { data: { product: [mockProducts[0]] } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
+    it('uses GetProductsSorted when only sortBy is provided', (done) => {
+      service.getProducts('asc').subscribe(() => done());
 
-      const result$ = service.getProducts(undefined, 'Electronics');
-
-      result$.subscribe((result: any) => {
-        expect(result.data.product).toEqual([mockProducts[0]]);
-      });
-
-      const call = apolloSpy.watchQuery.calls.mostRecent();
-      expect(call.args[0].variables).toEqual({ category: 'Electronics' });
+      const op = controller.expectOne('GetProductsSorted');
+      expect(op.operation.variables).toEqual({ sortBy: 'asc' });
+      op.flushData({ product: mockProducts });
     });
 
-    it('should get products with sortBy filter', () => {
-      const mockResponse = { data: { product: mockProducts } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
+    it('falls back to GetProductsDefault when no arguments are provided', (done) => {
+      service.getProducts().subscribe(() => done());
 
-      const result$ = service.getProducts('asc');
-
-      result$.subscribe((result: any) => {
-        expect(result.data.product).toEqual(mockProducts);
-      });
-
-      const call = apolloSpy.watchQuery.calls.mostRecent();
-      expect(call.args[0].variables).toEqual({ sortBy: 'asc' });
-    });
-
-    it('should get products with both category and sortBy', () => {
-      const mockResponse = { data: { product: [mockProducts[0]] } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
-
-      const result$ = service.getProducts('desc', 'Electronics');
-
-      result$.subscribe((result: any) => {
-        expect(result.data.product).toEqual([mockProducts[0]]);
-      });
-
-      const call = apolloSpy.watchQuery.calls.mostRecent();
-      expect(call.args[0].variables).toEqual({ category: 'Electronics', sortBy: 'desc' });
-    });
-  });
-
-  describe('getProductsDefault', () => {
-    it('should get default products list', () => {
-      const mockResponse = { data: { product: mockProducts } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
-
-      const result$ = service.getProductsDefault();
-
-      result$.subscribe((result: any) => {
-        expect(result.data.product).toEqual(mockProducts);
-      });
-
-      expect(apolloSpy.watchQuery).toHaveBeenCalled();
+      const op = controller.expectOne('GetProductsDefault');
+      expect(op.operation.variables).toEqual({});
+      op.flushData({ product: mockProducts });
     });
   });
 
   describe('getProductsByPrice', () => {
-    it('should get products within price range', () => {
-      const filteredProducts = [mockProducts[2]];
-      const mockResponse = { data: { product: filteredProducts } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
-
-      const result$ = service.getProductsByPrice(10, 50);
-
-      result$.subscribe((result: any) => {
-        expect(result.data.product).toEqual(filteredProducts);
+    it('sends the price bounds and returns the matching products', (done) => {
+      service.getProductsByPrice(10, 50).subscribe((r: any) => {
+        expect(r.data.product).toEqual([mockProducts[2]]);
+        done();
       });
 
-      const call = apolloSpy.watchQuery.calls.mostRecent();
-      expect(call.args[0].variables).toEqual({ priceFrom: 10, priceTo: 50 });
+      const op = controller.expectOne('GetProductsByPrice');
+      expect(op.operation.variables).toEqual({ priceFrom: 10, priceTo: 50 });
+      op.flushData({ product: [asGql(mockProducts[2])] });
     });
 
-    it('should handle minimum price of 0', () => {
-      const mockResponse = { data: { product: mockProducts } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
+    it('preserves a lower bound of 0 (no falsy coercion)', (done) => {
+      service.getProductsByPrice(0, 5000).subscribe(() => done());
 
-      const result$ = service.getProductsByPrice(0, 5000);
-
-      result$.subscribe((result: any) => {
-        expect(result.data.product).toEqual(mockProducts);
-      });
-
-      const call = apolloSpy.watchQuery.calls.mostRecent();
-      expect(call.args[0].variables?.['priceFrom']).toBe(0);
+      const op = controller.expectOne('GetProductsByPrice');
+      expect(op.operation.variables['priceFrom']).toBe(0);
+      op.flushData({ product: mockProducts });
     });
   });
 
   describe('searchProducts', () => {
-    it('should search products by name', () => {
-      const searchResults = [mockProducts[0]];
-      const mockResponse = { data: { product: searchResults } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
+    it('wraps the search term in SQL wildcards for _ilike', (done) => {
+      service.searchProducts('iPhone').subscribe(() => done());
 
-      const result$ = service.searchProducts('iPhone');
-
-      result$.subscribe((result: any) => {
-        expect(result.data.product).toEqual(searchResults);
-      });
-
-      const call = apolloSpy.watchQuery.calls.mostRecent();
-      expect(call.args[0].variables?.['searchInput']).toBe('%iPhone%');
+      const op = controller.expectOne('SearchProducts');
+      expect(op.operation.variables).toEqual({ searchInput: '%iPhone%' });
+      op.flushData({ product: [mockProducts[0]] });
     });
 
-    it('should wrap search input with wildcards', () => {
-      const mockResponse = { data: { product: [] } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
+    it('still wildcard-wraps an empty search term', (done) => {
+      service.searchProducts('').subscribe(() => done());
 
-      service.searchProducts('test').subscribe();
-
-      const call = apolloSpy.watchQuery.calls.mostRecent();
-      expect(call.args[0].variables?.['searchInput']).toBe('%test%');
-    });
-
-    it('should handle empty search results', () => {
-      const mockResponse = { data: { product: [] } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
-
-      const result$ = service.searchProducts('nonexistent');
-
-      result$.subscribe((result: any) => {
-        expect(result.data.product).toEqual([]);
-      });
+      const op = controller.expectOne('SearchProducts');
+      expect(op.operation.variables['searchInput']).toBe('%%');
+      op.flushData({ product: [] });
     });
   });
 
   describe('getProductById', () => {
-    it('should get product by id', () => {
-      const mockResponse = { data: { product: [mockProduct] } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
-
-      const result$ = service.getProductById(1);
-
-      result$.subscribe((result: any) => {
-        expect(result.data.product).toEqual([mockProduct]);
+    it('sends the id and returns the product', (done) => {
+      service.getProductById(5).subscribe((r: any) => {
+        expect(r.data.product[0].id).toBe(5);
+        done();
       });
 
-      const call = apolloSpy.watchQuery.calls.mostRecent();
-      expect(call.args[0].variables).toEqual({ id: 1 });
+      const op = controller.expectOne('GetProductById');
+      expect(op.operation.variables).toEqual({ id: 5 });
+      op.flushData({ product: [asGql(mockProducts[4])] });
     });
 
-    it('should handle numeric id correctly', () => {
-      const mockResponse = { data: { product: [mockProducts[4]] } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
-
-      const result$ = service.getProductById(5);
-
-      result$.subscribe((result: any) => {
-        expect(result.data.product[0].id).toBe(5);
+    it('returns an empty list for a non-existent id', (done) => {
+      service.getProductById(999).subscribe((r: any) => {
+        expect(r.data.product).toEqual([]);
+        done();
       });
 
-      const call = apolloSpy.watchQuery.calls.mostRecent();
-      expect(call.args[0].variables?.['id']).toBe(5);
-    });
-
-    it('should return empty array for non-existent id', () => {
-      const mockResponse = { data: { product: [] } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
-
-      const result$ = service.getProductById(999);
-
-      result$.subscribe((result: any) => {
-        expect(result.data.product).toEqual([]);
-      });
-    });
-  });
-
-  describe('getProductsByCategory', () => {
-    it('should get products by category', () => {
-      const electronicsProducts = mockProducts.filter(p => p.categoryId === 1);
-      const mockResponse = { data: { product: electronicsProducts } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
-
-      const result$ = service.getProductsByCategory('Electronics');
-
-      result$.subscribe((result: any) => {
-        expect(result.data.product).toEqual(electronicsProducts);
-      });
-
-      const call = apolloSpy.watchQuery.calls.mostRecent();
-      expect(call.args[0].variables).toEqual({ category: 'Electronics' });
-    });
-
-    it('should handle different category names', () => {
-      const clothingProducts = mockProducts.filter(p => p.categoryId === 2);
-      const mockResponse = { data: { product: clothingProducts } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
-
-      const result$ = service.getProductsByCategory('Clothing');
-
-      result$.subscribe((result: any) => {
-        expect(result.data.product).toEqual(clothingProducts);
-      });
+      controller.expectOne('GetProductById').flushData({ product: [] });
     });
   });
 
   describe('getFilteredProducts', () => {
-    it('should get products filtered by subcategories', () => {
-      const filtered = [mockProducts[0]];
-      const mockResponse = { data: { product: filtered } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
+    it('queries GetFilteredProducts with the subcategory list', (done) => {
+      service.getFilteredProducts(['Smartphones', 'Laptops']).subscribe(() => done());
 
-      const result$ = service.getFilteredProducts(['Smartphones']);
-
-      result$.subscribe((result: any) => {
-        expect(result.data.product).toEqual(filtered);
-      });
-
-      const call = apolloSpy.watchQuery.calls.mostRecent();
-      expect(call.args[0].variables).toEqual({ filter: ['Smartphones'] });
+      const op = controller.expectOne('GetFilteredProducts');
+      expect(op.operation.variables).toEqual({ filter: ['Smartphones', 'Laptops'] });
+      op.flushData({ product: [mockProducts[0], mockProducts[1]] });
     });
 
-    it('should get default products when filter is empty', () => {
-      const mockResponse = { data: { product: mockProducts } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
+    it('short-circuits to GetProductsDefault for an empty filter (no needless filtered query)', (done) => {
+      service.getFilteredProducts([]).subscribe(() => done());
 
-      const result$ = service.getFilteredProducts([]);
-
-      result$.subscribe((result: any) => {
-        expect(result.data.product).toEqual(mockProducts);
-      });
-
-      expect(apolloSpy.watchQuery).toHaveBeenCalled();
-    });
-
-    it('should handle multiple subcategory filters', () => {
-      const filtered = [mockProducts[0], mockProducts[1]];
-      const mockResponse = { data: { product: filtered } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
-
-      const result$ = service.getFilteredProducts(['Smartphones', 'Laptops']);
-
-      result$.subscribe((result: any) => {
-        expect(result.data.product).toEqual(filtered);
-      });
-
-      const call = apolloSpy.watchQuery.calls.mostRecent();
-      expect(call.args[0].variables?.['filter']).toEqual(['Smartphones', 'Laptops']);
+      controller.expectNone('GetFilteredProducts');
+      controller.expectOne('GetProductsDefault').flushData({ product: mockProducts });
     });
   });
 
   describe('getProductCategories', () => {
-    it('should get all categories with subcategories', () => {
-      const mockResponse = { data: { category: mockCategoriesWithSubcategories } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
-
-      const result$ = service.getProductCategories();
-
-      result$.subscribe((result: any) => {
-        expect(result.data.category).toEqual(mockCategoriesWithSubcategories);
-        expect(result.data.category.length).toBe(3);
-        expect(result.data.category[0].subcategories.length).toBe(2);
+    it('returns categories with their nested subcategories', (done) => {
+      service.getProductCategories().subscribe((r: any) => {
+        expect(r.data.category.length).toBe(3);
+        expect(r.data.category[0].subcategories.length).toBe(2);
+        done();
       });
 
-      expect(apolloSpy.watchQuery).toHaveBeenCalled();
-    });
-
-    it('should include subcategories in categories', () => {
-      const mockResponse = { data: { category: mockCategoriesWithSubcategories } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
-
-      const result$ = service.getProductCategories();
-
-      result$.subscribe((result: any) => {
-        const categories = result.data.category;
-        categories.forEach((category: any) => {
-          expect(category.subcategories).toBeDefined();
-          expect(Array.isArray(category.subcategories)).toBe(true);
-        });
-      });
+      controller
+        .expectOne('GetProductCategories')
+        .flushData({ category: mockCategoriesWithSubcategories });
     });
   });
 
   describe('getSuggestedProducts', () => {
-    it('should get limited number of suggested products', () => {
-      const suggestedProducts = mockProducts.slice(0, 10);
-      const mockResponse = { data: { product: suggestedProducts } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
-
-      const result$ = service.getSuggestedProducts();
-
-      result$.subscribe((result: any) => {
-        expect(result.data.product).toEqual(suggestedProducts);
-        expect(result.data.product.length).toBeLessThanOrEqual(10);
+    it('returns the suggested products payload', (done) => {
+      service.getSuggestedProducts().subscribe((r: any) => {
+        expect(r.data.product[0].id).toBe(mockProduct.id);
+        done();
       });
 
-      expect(apolloSpy.watchQuery).toHaveBeenCalled();
-    });
-
-    it('should return products with all required fields', () => {
-      const mockResponse = { data: { product: [mockProduct] } };
-      apolloSpy.watchQuery.and.returnValue(createMockWatchQueryResponse(mockResponse) as any);
-
-      const result$ = service.getSuggestedProducts();
-
-      result$.subscribe((result: any) => {
-        const product = result.data.product[0];
-        expect(product.id).toBeDefined();
-        expect(product.name).toBeDefined();
-        expect(product.price).toBeDefined();
-        expect(product.images).toBeDefined();
-      });
+      controller.expectOne('GetSuggestedProducts').flushData({ product: [asGql(mockProduct)] });
     });
   });
 
-  describe('Integration Tests', () => {
-    it('should handle multiple service calls independently', () => {
-      const mockResponse1 = { data: { product: [mockProducts[0]] } };
-      const mockResponse2 = { data: { product: [mockProducts[1]] } };
+  describe('legacy aliases', () => {
+    it('getProductBySubcategory delegates to the category query', (done) => {
+      service.getProductBySubcategory('Clothing').subscribe(() => done());
 
-      apolloSpy.watchQuery.and.returnValues(
-        createMockWatchQueryResponse(mockResponse1) as any,
-        createMockWatchQueryResponse(mockResponse2) as any
-      );
-
-      service.getProductById(1).subscribe((result: any) => {
-        expect(result.data.product).toEqual([mockProducts[0]]);
-      });
-
-      service.getProductById(2).subscribe((result: any) => {
-        expect(result.data.product).toEqual([mockProducts[1]]);
-      });
-
-      expect(apolloSpy.watchQuery).toHaveBeenCalledTimes(2);
+      const op = controller.expectOne('GetProductsByCategory');
+      expect(op.operation.variables).toEqual({ category: 'Clothing' });
+      op.flushData({ product: [] });
     });
 
-    it('should handle category filter updates', (done) => {
-      const categories = ['Electronics', 'Clothing'];
-      let index = 0;
+    it('getProductsFromSubcategories delegates to the filtered query', (done) => {
+      service.getProductsFromSubcategories(['Jeans']).subscribe(() => done());
 
-      service.categoryFilter.subscribe(category => {
-        expect(category).toBe(categories[index]);
-        index++;
-        if (index === categories.length) {
+      const op = controller.expectOne('GetFilteredProducts');
+      expect(op.operation.variables).toEqual({ filter: ['Jeans'] });
+      op.flushData({ product: [] });
+    });
+  });
+
+  describe('error handling (the path the old happy-only suite never covered)', () => {
+    it('surfaces a network error to the subscriber instead of swallowing it', (done) => {
+      service.getProductById(1).subscribe({
+        next: () => fail('expected the stream to error, not emit'),
+        error: (err) => {
+          expect(err).toBeTruthy();
           done();
-        }
+        },
       });
 
-      categories.forEach(cat => service.setCategoryFilter(cat));
+      controller.expectOne('GetProductById').networkError(new Error('Network failure'));
+    });
+
+    it('surfaces GraphQL errors to the subscriber', (done) => {
+      service.getProductsDefault().subscribe({
+        next: () => fail('expected the stream to error, not emit'),
+        error: (err) => {
+          expect(err).toBeTruthy();
+          done();
+        },
+      });
+
+      controller
+        .expectOne('GetProductsDefault')
+        .graphqlErrors([{ message: 'field "product" not found' } as any]);
     });
   });
 });

--- a/src/app/features/wishlist/wishlist-view.component.spec.ts
+++ b/src/app/features/wishlist/wishlist-view.component.spec.ts
@@ -1,23 +1,59 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { MessageService } from 'primeng/api';
+import { of } from 'rxjs';
 
 import { WishlistViewComponent } from './wishlist-view.component';
+import { WishlistService } from 'src/app/shared/wishlist.service';
+import { CartService } from 'src/app/shared/cart.service';
+import { mockProducts } from 'src/app/testing/mock-data';
 
+/**
+ * The CLI stub threw `NullInjectorError: No provider for MessageService!`. With
+ * doubles in place we also cover ngOnInit populating the wishlist and the
+ * cart delegation methods.
+ */
 describe('WishlistViewComponent', () => {
   let component: WishlistViewComponent;
   let fixture: ComponentFixture<WishlistViewComponent>;
+  let wishlist: jasmine.SpyObj<WishlistService>;
+  let cart: jasmine.SpyObj<CartService>;
 
   beforeEach(async () => {
+    wishlist = jasmine.createSpyObj('WishlistService', ['getWishListItems', 'removeWishListItem']);
+    cart = jasmine.createSpyObj('CartService', ['addToCart', 'removeFromCart']);
+    wishlist.getWishListItems.and.returnValue(of([mockProducts[0], mockProducts[1]]));
+
     await TestBed.configureTestingModule({
-      declarations: [WishlistViewComponent]
-    })
-      .compileComponents();
+      declarations: [WishlistViewComponent],
+      providers: [
+        { provide: WishlistService, useValue: wishlist },
+        { provide: CartService, useValue: cart },
+        MessageService,
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(WishlistViewComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('ngOnInit loads the wishlist items from the service', () => {
+    component.ngOnInit();
+    expect(component.wishlistItems).toEqual([mockProducts[0], mockProducts[1]]);
+  });
+
+  it('addToCart delegates to CartService', () => {
+    component.addToCart(mockProducts[0]);
+    expect(cart.addToCart).toHaveBeenCalledOnceWith(mockProducts[0]);
+  });
+
+  it('removeFromCart delegates to CartService', () => {
+    component.removeFromCart(mockProducts[0]);
+    expect(cart.removeFromCart).toHaveBeenCalledOnceWith(mockProducts[0]);
   });
 });

--- a/src/app/shared/cart.service.spec.ts
+++ b/src/app/shared/cart.service.spec.ts
@@ -223,6 +223,24 @@ describe('CartService', () => {
         done();
       });
     });
+
+    // Edge case the happy-path tests miss: removeFromCart filters by id, so a
+    // single remove drops EVERY copy of a duplicated product rather than
+    // decrementing a quantity. This test documents that behaviour (and flags it
+    // as a latent bug: the cart models quantity by repeating items, but removal
+    // does not match that model).
+    it('removes ALL copies of a duplicated product in a single call', (done) => {
+      service.addToCart(mockProducts[0]);
+      service.addToCart(mockProducts[0]);
+
+      service.removeFromCart(mockProducts[0]);
+
+      service.getCartItems().subscribe(items => {
+        expect(items.length).toBe(0); // both copies gone, not one
+        expect(service.inCart(mockProducts[0].id)).toBe(false);
+        done();
+      });
+    });
   });
 
   describe('getCartItems', () => {

--- a/src/app/shared/not-found/not-found.component.spec.ts
+++ b/src/app/shared/not-found/not-found.component.spec.ts
@@ -1,23 +1,37 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { Router } from '@angular/router';
 
 import { NotFoundComponent } from './not-found.component';
 
+/**
+ * NotFoundComponent injects Router, which the CLI stub did not provide
+ * (NullInjectorError). Inject a spy and cover the single navigation method.
+ */
 describe('NotFoundComponent', () => {
   let component: NotFoundComponent;
   let fixture: ComponentFixture<NotFoundComponent>;
+  let router: jasmine.SpyObj<Router>;
 
   beforeEach(async () => {
+    router = jasmine.createSpyObj('Router', ['navigate']);
+
     await TestBed.configureTestingModule({
-      declarations: [ NotFoundComponent ]
-    })
-    .compileComponents();
+      declarations: [NotFoundComponent],
+      providers: [{ provide: Router, useValue: router }],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(NotFoundComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('toHome navigates back to the home route', () => {
+    component.toHome();
+    expect(router.navigate).toHaveBeenCalledWith(['home']);
   });
 });

--- a/src/app/shared/product-image.service.spec.ts
+++ b/src/app/shared/product-image.service.spec.ts
@@ -1,0 +1,140 @@
+import { TestBed } from '@angular/core/testing';
+import { ProductImageService } from './product-image.service';
+
+/**
+ * Unit tests for ProductImageService.
+ *
+ * Before this suite the service had ZERO coverage even though it contains the
+ * only non-trivial branching logic in `src/app/shared` (image normalization and
+ * the multi-step <img> error fallback chain). The tests below exercise every
+ * branch and the edge cases that production data actually hits: null/undefined
+ * image arrays, whitespace-only entries, more images than the cap, and each
+ * stage of the error-fallback state machine.
+ */
+describe('ProductImageService', () => {
+  let service: ProductImageService;
+  const ASSET_FALLBACK = 'assets/images/product-placeholder.png';
+  const NAME_FALLBACK_PREFIX = 'https://placehold.co/600x600/png?text=';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [ProductImageService] });
+    service = TestBed.inject(ProductImageService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getFallbackImageByName', () => {
+    it('encodes the product name into the placeholder URL', () => {
+      expect(service.getFallbackImageByName('iPhone 13 Pro')).toBe(
+        `${NAME_FALLBACK_PREFIX}${encodeURIComponent('iPhone 13 Pro')}`
+      );
+    });
+
+    it('URL-encodes names with reserved characters (no broken URLs)', () => {
+      expect(service.getFallbackImageByName('Tom & Jerry / 50% off?')).toBe(
+        `${NAME_FALLBACK_PREFIX}${encodeURIComponent('Tom & Jerry / 50% off?')}`
+      );
+    });
+
+    it('falls back to "Product Image" for null, undefined, empty and whitespace', () => {
+      const expected = `${NAME_FALLBACK_PREFIX}${encodeURIComponent('Product Image')}`;
+      expect(service.getFallbackImageByName(null)).toBe(expected);
+      expect(service.getFallbackImageByName(undefined)).toBe(expected);
+      expect(service.getFallbackImageByName('')).toBe(expected);
+      expect(service.getFallbackImageByName('   ')).toBe(expected);
+    });
+  });
+
+  describe('normalizeImages', () => {
+    it('returns the first two images untouched when two or more are valid', () => {
+      expect(service.normalizeImages(['a.jpg', 'b.jpg', 'c.jpg'], 'Phone')).toEqual([
+        'a.jpg',
+        'b.jpg',
+      ]);
+    });
+
+    it('pads a single valid image with a name-based placeholder', () => {
+      expect(service.normalizeImages(['only.jpg'], 'Chair')).toEqual([
+        'only.jpg',
+        service.getFallbackImageByName('Chair'),
+      ]);
+    });
+
+    it('returns [name placeholder, asset placeholder] when there are no valid images', () => {
+      expect(service.normalizeImages([], 'Chair')).toEqual([
+        service.getFallbackImageByName('Chair'),
+        ASSET_FALLBACK,
+      ]);
+    });
+
+    it('treats null/undefined image arrays as empty (no crash on bad API data)', () => {
+      const expected = [service.getFallbackImageByName('Chair'), ASSET_FALLBACK];
+      expect(service.normalizeImages(null, 'Chair')).toEqual(expected);
+      expect(service.normalizeImages(undefined, 'Chair')).toEqual(expected);
+    });
+
+    it('trims entries and drops whitespace-only / falsy entries before counting', () => {
+      // After trimming, only 'real.jpg' survives -> treated as the single-image case.
+      expect(
+        service.normalizeImages(['   ', '', null as any, '  real.jpg  '], 'Chair')
+      ).toEqual(['real.jpg', service.getFallbackImageByName('Chair')]);
+    });
+
+    it('caps the result at two images even when many valid images are supplied', () => {
+      const many = ['1.jpg', '2.jpg', '3.jpg', '4.jpg', '5.jpg'];
+      expect(service.normalizeImages(many, 'X').length).toBe(2);
+    });
+  });
+
+  describe('resolvePrimaryImage', () => {
+    it('returns the first valid image', () => {
+      expect(service.resolvePrimaryImage(['a.jpg', 'b.jpg'], 'X')).toBe('a.jpg');
+    });
+
+    it('returns the name placeholder when no valid images exist', () => {
+      expect(service.resolvePrimaryImage([], 'Office Chair')).toBe(
+        service.getFallbackImageByName('Office Chair')
+      );
+    });
+  });
+
+  describe('handleImageError (fallback state machine)', () => {
+    /** Minimal stub of the parts of HTMLImageElement the service reads/writes. */
+    function imgStub(src: string, currentSrc = ''): HTMLImageElement {
+      return { src, currentSrc } as HTMLImageElement;
+    }
+
+    it('does nothing when the event has no target', () => {
+      expect(() =>
+        service.handleImageError({ target: null } as unknown as Event, 'X')
+      ).not.toThrow();
+    });
+
+    it('step 1: a failing real image swaps to the name-based placeholder', () => {
+      const img = imgStub('https://cdn.example.com/real.jpg');
+      service.handleImageError({ target: img } as unknown as Event, 'iPhone');
+      expect(img.src).toBe(service.getFallbackImageByName('iPhone'));
+    });
+
+    it('step 2: a failing name placeholder swaps to the local asset placeholder', () => {
+      const img = imgStub(service.getFallbackImageByName('iPhone'));
+      service.handleImageError({ target: img } as unknown as Event, 'iPhone');
+      expect(img.src).toBe(ASSET_FALLBACK);
+    });
+
+    it('step 3: a failing asset placeholder is left alone (no infinite loop)', () => {
+      const img = imgStub(`http://localhost/${ASSET_FALLBACK}`);
+      service.handleImageError({ target: img } as unknown as Event, 'iPhone');
+      expect(img.src).toBe(`http://localhost/${ASSET_FALLBACK}`);
+    });
+
+    it('prefers currentSrc over src when deciding the current stage', () => {
+      // currentSrc already points at the name placeholder -> advance to asset.
+      const img = imgStub('whatever.jpg', service.getFallbackImageByName('iPhone'));
+      service.handleImageError({ target: img } as unknown as Event, 'iPhone');
+      expect(img.src).toBe(ASSET_FALLBACK);
+    });
+  });
+});


### PR DESCRIPTION
## Why

A review of the test suite found it was largely **non-functional**: running `ng test` failed ~20 of the first ~22 tests, and an uncontrolled async leak in the products-service spec disconnected the Karma browser and **hung the whole run**. Most "tests" were the Angular CLI `should create` stubs that threw `NullInjectorError` / `NG0304` before asserting anything, and the products-service spec's mock double-wrapped its payload so every data assertion silently compared against `undefined`.

This PR makes the suite **green and meaningful**: **168 passing**, statement coverage **~72%** overall and **~100%** on the shared services. No production code is changed — tests only.

## What changed

**Services & external-dependency integration**
- **`products.service.spec`** rewritten on `ApolloTestingModule`. Instead of a hand-rolled `watchQuery` spy, the tests now exercise the real Apollo links: assert the actual **GraphQL operation name + variables**, flush controlled responses, and — new — cover **network and GraphQL error paths**. Fixes the double-wrapped dead assertions and removes the leaked subscription that threw in `afterAll`.
- **`product-image.service.spec`** added (was **zero coverage**): full branch coverage of image normalization and the `<img>` error-fallback state machine, including null/`undefined`/whitespace/over-cap edge cases.
- **`cart.service.spec`**: added a test documenting a latent edge case — `removeFromCart` filters by id, so a single remove drops **every** copy of a duplicated product (quantity isn't modelled).

**Components**
- Replaced the broken CLI `should create` stubs (which threw `NullInjectorError`/`NG0304`/`NG0303`) with proper `TestBed` setups (DI doubles, `NO_ERRORS_SCHEMA`) and **behavioural** assertions: wishlist/cart toggles + PrimeNG toasts, installment maths, route-dependent navigation, header counters, cart quantity/total logic, and service handoffs.
- **`payment.component.spec`** added (checkout step, was **zero coverage**).
- Fixed **stale** `app.component.spec` assertions (it still asserted `title === 'datastructures'` and a CLI welcome banner the app no longer renders).

## Coverage (per area, statements)

| Area | Before | After |
|---|---|---|
| shared services | broken/0 | ~100% |
| app root / home / main-layout | broken/0 | 100% |
| cart-view | broken/0 | ~77% |
| products | broken/0 | ~57% |
| wishlist | broken/0 | ~61% |

The heavy view components (`product-details`, `products-view`) are covered at the construction + pure-method level; deeper rendering/interaction coverage is best done as follow-up.

## Out of scope (flagged for follow-up)
- The **Cypress E2E suite tests a UI that doesn't exist** — all 73 `data-cy` selectors it relies on are absent from the templates, and `home.cy.ts` hardcodes `localhost:4200`, brittle full-path CSS selectors, and product names from live backend data. It needs a separate rework.

https://claude.ai/code/session_01DU6LjxcPRLQW76WqhaYa8L

---
_Generated by [Claude Code](https://claude.ai/code/session_01DU6LjxcPRLQW76WqhaYa8L)_