### PR TITLE
feat(styles): establish design token foundation

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,9 +1,15 @@
-/* You can add global styles to this file, and also import other style files */
-@import "primeicons/primeicons.css";
-@import url("https://fonts.googleapis.com/css2?family=Inter&family=Poppins&family=Rubik:wght@400;500;700&display=swap");
+/* =============================================================================
+   Global styles. Design values live in styles/tokens.scss — consume via var().
+   ============================================================================= */
 
-* {
-  font-family: "Inter", sans-serif;
+/* Brand fonts: Syne (display) · DM Sans (body) · JetBrains Mono (data/code). */
+@import url("https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=JetBrains+Mono:wght@400;500&family=Syne:wght@600;700;800&display=swap");
+@import "primeicons/primeicons.css";
+@import "styles/tokens";
+
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
@@ -15,15 +21,176 @@ body {
   width: 100%;
 }
 
-p,
+body {
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  font-weight: 400;
+  line-height: 1.6;
+  color: var(--color-text-primary);
+  background-color: var(--color-bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+/* Headings use the display family with tight tracking (see Typography Rules). */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  color: var(--color-text-primary);
+}
+
 h1 {
-  padding: 0;
+  font-size: var(--text-3xl);
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+}
+
+h2 {
+  font-size: var(--text-2xl);
+}
+
+h3 {
+  font-size: var(--text-xl);
+}
+
+h4 {
+  font-size: var(--text-lg);
+}
+
+p {
   margin: 0;
 }
 
-// Global styles
+/* Native form controls don't inherit font by default — opt them in. */
+button,
+input,
+select,
+textarea {
+  font-family: inherit;
+}
+
+/* Keep the whole app on the brand body font, including PrimeNG components.
+   `body .p-component` outranks the theme's `.p-component` without !important. */
+body .p-component {
+  font-family: var(--font-body);
+}
+
+/* Utility: monospaced data/figures (prices, SKUs, counts). */
+.font-mono {
+  font-family: var(--font-mono);
+}
+
+/* Existing centering helper. */
 .center {
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+/* ---------------------------------------------------------------------------
+   Accessibility primitives
+   --------------------------------------------------------------------------- */
+
+/* Accessible focus ring — replaces the default outline, never just removes it. */
+:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+  border-radius: var(--radius-sm);
+}
+
+/* Visually hidden but available to screen readers. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Skip-navigation link — hidden until focused, then slides into view. */
+.skip-link {
+  position: absolute;
+  left: var(--space-2);
+  top: var(--space-2);
+  z-index: 1000;
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-surface-elevated);
+  color: var(--color-text-primary);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-150%);
+  transition: transform var(--duration-base) var(--ease-out);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+/* ---------------------------------------------------------------------------
+   Loading & entrance primitives
+   --------------------------------------------------------------------------- */
+
+/* Skeleton shimmer — shape these to match the real content they stand in for. */
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--color-surface) 25%,
+    var(--color-surface-elevated) 50%,
+    var(--color-surface) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.6s ease-in-out infinite;
+  border-radius: var(--radius-sm);
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* Entrance animation — opacity + transform only (GPU-composited). */
+@keyframes enter {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.component-enter {
+  animation: enter var(--duration-enter) var(--ease-out) both;
+}
+
+/* ---------------------------------------------------------------------------
+   Reduced motion — mandatory. The !important here is the sanctioned exception
+   from CLAUDE.md's required snippet.
+   --------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
 }

--- a/src/styles/tokens.scss
+++ b/src/styles/tokens.scss
@@ -1,0 +1,109 @@
+/* =============================================================================
+   Design Tokens — single source of truth for all visual values.
+   Consume these via var(--token); never hardcode hex, magic numbers, or fonts
+   in component styles. See CLAUDE.md › Frontend Design Standards.
+
+   Aesthetic direction: a warm, paper-toned neutral palette with a single clay
+   accent used sparingly. Deliberately not the purple-on-white AI default, and
+   deliberately not Inter/Roboto/Arial.
+   ============================================================================= */
+
+:root {
+  /* ---------------------------------------------------------------------------
+     Backgrounds & surfaces  (3-level warm neutral elevation)
+     --------------------------------------------------------------------------- */
+  --color-bg: #f0eee8;                 /* page background — warm paper        */
+  --color-surface: #fbfaf7;            /* card / panel — sits above bg        */
+  --color-surface-elevated: #ffffff;   /* modal / dropdown + shimmer highlight */
+  --color-border: #e4e1d8;             /* subtle warm divider                 */
+
+  /* ---------------------------------------------------------------------------
+     Text
+     --------------------------------------------------------------------------- */
+  --color-text-primary: #1d1b16;       /* warm near-black                     */
+  --color-text-secondary: #6f6a5e;     /* warm muted grey                     */
+
+  /* ---------------------------------------------------------------------------
+     Accent — one color, used sparingly (CTAs, focus, active nav)
+     --------------------------------------------------------------------------- */
+  --color-accent: #d9622b;             /* clay / vermilion                    */
+  --color-accent-strong: #b94e1f;      /* hover / pressed accent              */
+  --color-accent-dim: rgba(217, 98, 43, 0.14); /* ~10% accent for focus rings */
+
+  /* ---------------------------------------------------------------------------
+     Semantic — paired with icon/text in UI, never color alone
+     --------------------------------------------------------------------------- */
+  --color-danger: #c8453b;
+  --color-danger-dim: rgba(200, 69, 59, 0.12);
+  --color-success: #2f8559;
+  --color-success-dim: rgba(47, 133, 89, 0.12);
+  --color-warning: #c98a12;
+  --color-warning-dim: rgba(201, 138, 18, 0.14);
+
+  /* ---------------------------------------------------------------------------
+     Typography — font families
+     Display: Syne · Body: DM Sans · Data/code: JetBrains Mono
+     --------------------------------------------------------------------------- */
+  --font-display: "Syne", "Segoe UI", system-ui, sans-serif;
+  --font-body: "DM Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", "Cascadia Code", Menlo, monospace;
+
+  /* ---------------------------------------------------------------------------
+     Fluid type scale — clamp(min, preferred, max), mobile-first
+     --------------------------------------------------------------------------- */
+  --text-xs: clamp(0.75rem, 0.73rem + 0.10vw, 0.8125rem);    /* 12 → 13 */
+  --text-sm: clamp(0.875rem, 0.85rem + 0.12vw, 0.9375rem);   /* 14 → 15 */
+  --text-base: clamp(1rem, 0.97rem + 0.18vw, 1.0625rem);     /* 16 → 17 */
+  --text-lg: clamp(1.125rem, 1.07rem + 0.30vw, 1.3125rem);   /* 18 → 21 */
+  --text-xl: clamp(1.375rem, 1.27rem + 0.55vw, 1.625rem);    /* 22 → 26 */
+  --text-2xl: clamp(1.75rem, 1.54rem + 1.05vw, 2.25rem);     /* 28 → 36 */
+  --text-3xl: clamp(2.25rem, 1.88rem + 1.85vw, 3.25rem);     /* 36 → 52 */
+
+  /* ---------------------------------------------------------------------------
+     Spacing — 4px grid
+     --------------------------------------------------------------------------- */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+  --space-24: 6rem;
+  --space-32: 8rem;
+
+  /* ---------------------------------------------------------------------------
+     Border radius
+     --------------------------------------------------------------------------- */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 16px;
+  --radius-xl: 24px;
+  --radius-full: 9999px;
+
+  /* ---------------------------------------------------------------------------
+     Shadows — warm-tinted (based on text-primary rgb), layered for realism
+     --------------------------------------------------------------------------- */
+  --shadow-sm: 0 1px 2px rgba(29, 27, 22, 0.06), 0 1px 1px rgba(29, 27, 22, 0.04);
+  --shadow-md: 0 4px 12px rgba(29, 27, 22, 0.08), 0 2px 4px rgba(29, 27, 22, 0.05);
+  --shadow-lg: 0 18px 44px rgba(29, 27, 22, 0.13), 0 6px 14px rgba(29, 27, 22, 0.07);
+  --shadow-glow: 0 0 0 1px rgba(217, 98, 43, 0.20), 0 10px 30px rgba(217, 98, 43, 0.26);
+
+  /* ---------------------------------------------------------------------------
+     Animation
+     --------------------------------------------------------------------------- */
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in: cubic-bezier(0.4, 0, 1, 1);
+  --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+  --duration-fast: 120ms;
+  --duration-base: 200ms;
+  --duration-slow: 400ms;
+  --duration-enter: 500ms;
+
+  /* ---------------------------------------------------------------------------
+     Layout & convenience composites
+     --------------------------------------------------------------------------- */
+  --layout-max-width: 1200px;
+  --focus-ring: 0 0 0 3px var(--color-accent-dim); /* see :focus-visible in styles.scss */
+}


### PR DESCRIPTION
## What

Establishes the mandatory **design token foundation** required by the project's frontend design standards (`CLAUDE.md`). This is the prerequisite layer that every future component should build on — no token system existed yet.

## Changes

**New — `src/styles/tokens.scss`**
Single source of truth for all visual values, with opinionated defaults filling every category from the standards:

- **Palette:** warm paper-toned 3-level surface system (`#f0eee8` → `#fbfaf7` → `#fff`), warm near-black text, and a single **clay accent** (`#d9622b`) used sparingly — deliberately *not* the purple-on-white default. Each semantic color (danger/success/warning) ships with a `-dim` tint for state backgrounds.
- **Typography:** `Syne` (display) / `DM Sans` (body) / `JetBrains Mono` (data), plus a fluid `clamp()` type scale (`--text-xs` → `--text-3xl`).
- **Spacing** on a 4px grid, **radii**, layered warm **shadows** + accent glow, **easing/durations**, and convenience composites (`--layout-max-width`, `--focus-ring`).

**Rewritten — `src/styles.scss`**

- Removes the **banned `Inter`** font (import + `* { font-family }`) and loads the three brand families.
- Body → DM Sans; headings → Syne with the tracking/line-height from the type table. PrimeNG components are pulled onto the brand body font via `body .p-component` (no `!important`).
- Adds foundational primitives: accessible `:focus-visible` ring, `.sr-only`, `.skip-link`, `.skeleton` shimmer, `enter` keyframe, and the mandatory `prefers-reduced-motion` guard.

## Verification

- Compiles cleanly with dart-sass (`exit 0`); all utilities, keyframes, the reduced-motion block, and 27 `var()` references emit as expected.
- `node_modules` isn't present in this environment, so this was validated with a standalone Sass pass rather than a full `ng build`.

## Notes / follow-ups

- This PR sets up the *foundation only*. Migrating the existing ~18 component stylesheets onto the tokens (replacing hardcoded hex, adding the full interactive/async state set) is intentionally out of scope and can follow component-by-component.
- The `.skip-link` utility exists but still needs to be wired into the page layout(s) to fully satisfy the skip-nav requirement.

https://claude.ai/code/session_018Bv9Pp1kVxGuK5WRechDfF

---
_Generated by [Claude Code](https://claude.ai/code/session_018Bv9Pp1kVxGuK5WRechDfF)_