### PR TITLE
fix(products): contain grid images within product cards

### DIFF
--- a/src/app/features/products/product/product.component.html
+++ b/src/app/features/products/product/product.component.html
@@ -1,15 +1,13 @@
 <!-- Grid view -->
-<div *ngIf="!isListView; else listView" class="product-card transition-duration-500 p-2"
-     style="max-width: 100%; width: 100%; height: 100%;">
-    <div class="relative flex flex-column align-items-center" style="height: 100%;">
-        <div class="image-container flex justify-center items-center"
-             style="height: 200px; width: 200px; max-width: 100%; margin-bottom: 10px;">
+<div *ngIf="!isListView; else listView" class="product-card transition-duration-500">
+    <div class="product-card-body">
+        <div class="image-container">
             <img (click)="openProductDetails(id)" [src]="primaryImageSrc" [alt]="name" (error)="onImageError($event)"
-                 class="max-h-full max-w-full object-contain cursor-pointer" style="align-self: center; margin: auto;">
+                 class="product-image">
         </div>
-        <i (click)="addRemoveItemWishlist(product)" class="favorite absolute top-2 right-2 z-10 text-xl cursor-pointer"
+        <i (click)="addRemoveItemWishlist(product)" class="favorite"
            [class]="inWishlist ? 'pi pi-heart-fill wishlist' : 'pi pi-heart'"></i>
-        <div class="content-section flex-grow p-3" style="height: calc(100% - 200px);">
+        <div class="content-section">
       <span (click)="openProductDetails(id)"
             class="block text-base sm:text-lg font-bold mb-2 cursor-pointer hover:underline truncate text-center">{{ name }}</span>
             <span class="block text-xs sm:text-sm mb-2 h-10 overflow-hidden relative text-center"

--- a/src/app/features/products/product/product.component.scss
+++ b/src/app/features/products/product/product.component.scss
@@ -1,15 +1,15 @@
 .product-card {
   width: 100%;
+  min-width: 0;
   min-height: 100%;
   display: flex;
-  align-items: center;
-  justify-content: center;
   flex-direction: column;
   border-radius: var(--radius-lg);
   border: 1px solid var(--color-border);
   background: var(--color-surface);
   position: relative;
   margin: 0;
+  overflow: hidden;
   box-shadow: var(--shadow-sm);
   transition: box-shadow var(--duration-base) var(--ease-out),
     transform var(--duration-base) var(--ease-out),
@@ -20,6 +20,43 @@
     border-color: var(--color-accent);
     transform: translateY(-3px);
   }
+}
+
+.product-card-body {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  height: 100%;
+  min-width: 0;
+  padding: var(--space-2);
+}
+
+.image-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 12.5rem;
+  margin-bottom: var(--space-2);
+  overflow: hidden;
+  flex-shrink: 0;
+
+  .product-image {
+    max-width: 100%;
+    max-height: 100%;
+    width: auto;
+    height: auto;
+    object-fit: contain;
+    cursor: pointer;
+  }
+}
+
+.content-section {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  padding: var(--space-3);
 }
 
 .custom-ellipsis {

--- a/src/app/features/products/products-view.component.scss
+++ b/src/app/features/products/products-view.component.scss
@@ -2,6 +2,17 @@
   background: transparent;
 }
 
+:host ::ng-deep .p-dataview-grid .grid > div {
+  display: flex;
+  min-width: 0;
+
+  app-product {
+    display: block;
+    width: 100%;
+    min-width: 0;
+  }
+}
+
 .products-layout {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes product images overlapping and spilling outside their cards on the `/products/search` grid view.

## Problem

Grid product cards used a fixed 200px-wide image container with invalid flex utility classes (`justify-center`, `items-center`). In narrow grid columns, images could extend beyond the card border and overlap adjacent cards.

## Solution

- Replace inline image sizing with a responsive `.image-container` that uses `width: 100%`, a fixed height, and `overflow: hidden`
- Add `overflow: hidden` and `min-width: 0` to `.product-card` so content stays clipped inside the card
- Add grid-level flex containment in `products-view` so `app-product` respects column width in the PrimeNG DataView grid

## Files changed

- `src/app/features/products/product/product.component.html`
- `src/app/features/products/product/product.component.scss`
- `src/app/features/products/products-view.component.scss`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a49f2282-e25b-4093-ac75-02b645857898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a49f2282-e25b-4093-ac75-02b645857898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

