### PR TITLE
Set up dev environment + correct AGENTS.md unit-test caveat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ See `README.md` for clone/install/serve steps. Quick reference:
 
 - **Node:** Works on Node 22 in this environment; Angular 15 officially supports Node 14.20+, 16.13+, or 18.10+.
 - **Hasura auth:** The app sends `x-hasura-admin-secret` via Apollo (`app.module.ts`). Direct `curl` to the GraphQL endpoint without that header returns access-denied; use the running app or mirror those headers.
-- **Unit tests:** As of setup, many specs in `products.service.spec.ts` fail (mock/expectation mismatches). Lint, build, and the running app still work; do not assume green `ng test` means the environment is broken.
+- **Unit tests:** As of setup, `ng test` runs 168 specs with 167 passing; 1 spec in `footer.component.spec.ts` ("openLink opens the given URL in a new window") fails due to an outdated expectation (it ignores the `_blank`/`noopener` args the component actually passes). This is a spec mismatch, not an environment issue—lint, build, and the running app all work.
 - **Cypress:** `cypress.config.ts` has no `baseUrl`. Several specs use `[data-cy="..."]` attributes not present in `src/`. `home.cy.ts` references a removed Login nav link.
 - **No git hooks:** No Husky/pre-commit; nothing extra to run before commits.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Verified the Shoply Angular 15 dev environment end-to-end and corrected one inaccurate caveat in `AGENTS.md`.

- The failing unit spec is in `footer.component.spec.ts` (1 of 168 specs), not `products.service.spec.ts`. Updated the caveat to reflect actual results: 167/168 pass, and the one failure is a stale expectation (it ignores the `_blank`/`noopener` args the component passes).

## Environment verification

| Check | Command | Result |
|-------|---------|--------|
| Install | `npm install` | ✅ |
| Lint | `npx eslint "src/**/*.ts"` | ✅ clean |
| Build | `npm run build` | ✅ `dist/project` |
| Unit tests | `npm run test -- --browsers=ChromeHeadless --watch=false` | ⚠️ 167/168 (1 stale spec) |
| Dev server | `npm start -- --host 0.0.0.0 --port 4200` | ✅ HTTP 200 |

## Hello-world walkthrough

Home (catalog from Hasura) → product detail (TENDA AC8 Ruter, 6,690 RSD) → Buy now → cart shows item with badge `1`.

[shoply_add_to_cart_flow.mp4](https://cursor.com/agents/bc-c85873f7-e8e1-40f1-a764-5c430aed3be5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshoply_add_to_cart_flow.mp4)

[Home catalog](https://cursor.com/agents/bc-c85873f7-e8e1-40f1-a764-5c430aed3be5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshoply_home.webp)
[Cart with added item](https://cursor.com/agents/bc-c85873f7-e8e1-40f1-a764-5c430aed3be5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshoply_cart.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c85873f7-e8e1-40f1-a764-5c430aed3be5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c85873f7-e8e1-40f1-a764-5c430aed3be5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

